### PR TITLE
Stop reading from stdin after programmatic API finishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,10 @@ For more details, visit https://github.com/kimmobrunfeldt/concurrently
 concurrently can be used programmatically by using the API documented below:
 
 ### `concurrently(commands[, options])`
+
 - `commands`: an array of either strings (containing the commands to run) or objects
   with the shape `{ command, name, prefixColor, env, cwd }`.
+
 - `options` (optional): an object containing any of the below:
     - `cwd`: the working directory to be used by all commands. Can be overriden per command.
     Default: `process.cwd()`.
@@ -237,6 +239,7 @@ concurrently can be used programmatically by using the API documented below:
     Default: `0`.
     - `inputStream`: a [`Readable` stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_readable_streams)
     to read the input from, eg `process.stdin`.
+    - `pauseInputStreamOnFinish`: by default, pauses `inputStream` when all of the processes have finished. If you need to read from `inputStream` after `concurrently` has finished, set this to `false`. ([#252](https://github.com/kimmobrunfeldt/concurrently/issues/252)).
     - `killOthers`: an array of exitting conditions that will cause a process to kill others.
     Can contain any of `success` or `failure`.
     - `maxProcesses`: how many processes should run at once.

--- a/README.md
+++ b/README.md
@@ -237,9 +237,10 @@ concurrently can be used programmatically by using the API documented below:
     Default: `process.cwd()`.
     - `defaultInputTarget`: the default input target when reading from `inputStream`.
     Default: `0`.
+    - `handleInput`: when `true`, reads input from `process.stdin`.
     - `inputStream`: a [`Readable` stream](https://nodejs.org/dist/latest-v10.x/docs/api/stream.html#stream_readable_streams)
-    to read the input from, eg `process.stdin`.
-    - `pauseInputStreamOnFinish`: by default, pauses `inputStream` when all of the processes have finished. If you need to read from `inputStream` after `concurrently` has finished, set this to `false`. ([#252](https://github.com/kimmobrunfeldt/concurrently/issues/252)).
+    to read the input from. Should only be used in the rare instance you would like to stream anything other than `process.stdin`. Overrides `handleInput`.
+    - `pauseInputStreamOnFinish`: by default, pauses the input stream (`process.stdin` when `handleInput` is enabled, or `inputStream` if provided) when all of the processes have finished. If you need to read from the input stream after `concurrently` has finished, set this to `false`. ([#252](https://github.com/kimmobrunfeldt/concurrently/issues/252)).
     - `killOthers`: an array of exitting conditions that will cause a process to kill others.
     Can contain any of `success` or `failure`.
     - `maxProcesses`: how many processes should run at once.

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -157,7 +157,7 @@ concurrently(args._.map((command, index) => {
         name: names[index]
     };
 }), {
-    inputStream: args.handleInput && process.stdin,
+    handleInput: args.handleInput,
     defaultInputTarget: args.defaultInputTarget,
     killOthers: args.killOthers
         ? ['success', 'failure']

--- a/bin/concurrently.spec.js
+++ b/bin/concurrently.spec.js
@@ -193,7 +193,7 @@ describe('--names', () => {
 });
 
 describe('--prefix', () => {
-    it('is alised to -p', done => {
+    it('is aliased to -p', done => {
         const child = run('-p command "echo foo" "echo bar"');
         child.log.pipe(buffer(child.close)).subscribe(lines => {
             expect(lines).toContainEqual(expect.stringContaining('[echo foo] foo'));
@@ -213,7 +213,7 @@ describe('--prefix', () => {
 });
 
 describe('--prefix-length', () => {
-    it('is alised to -l', done => {
+    it('is aliased to -l', done => {
         const child = run('-p command -l 5 "echo foo" "echo bar"');
         child.log.pipe(buffer(child.close)).subscribe(lines => {
             expect(lines).toContainEqual(expect.stringContaining('[ec..o] foo'));
@@ -247,7 +247,7 @@ describe('--restart-tries', () => {
 });
 
 describe('--kill-others', () => {
-    it('is alised to -k', done => {
+    it('is aliased to -k', done => {
         const child = run('-k "sleep 10" "exit 0"');
         child.log.pipe(buffer(child.close)).subscribe(lines => {
             expect(lines).toContainEqual(expect.stringContaining('[1] exit 0 exited with code 0'));

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ module.exports = exports = (commands, options = {}) => {
                 logger,
                 defaultInputTarget: options.defaultInputTarget,
                 inputStream: options.inputStream,
+                pauseInputStreamOnFinish: options.pauseInputStreamOnFinish,
             }),
             new KillOnSignal({ process }),
             new RestartProcess({

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = exports = (commands, options = {}) => {
             new InputHandler({
                 logger,
                 defaultInputTarget: options.defaultInputTarget,
-                inputStream: options.inputStream,
+                inputStream: options.inputStream || (options.handleInput && process.stdin),
                 pauseInputStreamOnFinish: options.pauseInputStreamOnFinish,
             }),
             new KillOnSignal({ process }),

--- a/src/concurrently.js
+++ b/src/concurrently.js
@@ -50,7 +50,7 @@ module.exports = (commands, options) => {
         .value();
 
     commands = options.controllers.reduce(
-        (prevCommands, controller) => controller.handle(prevCommands),
+        (prevCommands, controller) => controller.handle(prevCommands).commands,
         commands
     );
 

--- a/src/concurrently.js
+++ b/src/concurrently.js
@@ -49,10 +49,17 @@ module.exports = (commands, options) => {
         ))
         .value();
 
-    commands = options.controllers.reduce(
-        (prevCommands, controller) => controller.handle(prevCommands).commands,
-        commands
+    const handleResult = options.controllers.reduce(
+        ({ commands: prevCommands, onFinishCallbacks }, controller) => {
+            const { commands, onFinish } = controller.handle(prevCommands);
+            return {
+                commands,
+                onFinishCallbacks: _.concat(onFinishCallbacks, onFinish ? [onFinish] : [])
+            }
+        },
+        { commands, onFinishCallbacks: [] }
     );
+    commands = handleResult.commands
 
     const commandsLeft = commands.slice();
     const maxProcesses = Math.max(1, Number(options.maxProcesses) || commandsLeft.length);
@@ -63,7 +70,7 @@ module.exports = (commands, options) => {
     return new CompletionListener({ successCondition: options.successCondition })
         .listen(commands)
         .finally(() => {
-            options.controllers.forEach((controller) => controller.onFinish());
+            handleResult.onFinishCallbacks.forEach((onFinish) => onFinish());
         });
 };
 

--- a/src/concurrently.js
+++ b/src/concurrently.js
@@ -60,7 +60,11 @@ module.exports = (commands, options) => {
         maybeRunMore(commandsLeft);
     }
 
-    return new CompletionListener({ successCondition: options.successCondition }).listen(commands);
+    return new CompletionListener({ successCondition: options.successCondition })
+        .listen(commands)
+        .finally(() => {
+            options.controllers.forEach((controller) => controller.onFinish());
+        });
 };
 
 function mapToCommandInfo(command) {

--- a/src/concurrently.spec.js
+++ b/src/concurrently.spec.js
@@ -166,3 +166,21 @@ it('uses overridden cwd option for each command if specified', () => {
         cwd: 'foobar',
     }));
 });
+
+it('runs onFinish hook after all commands run', async () => {
+    const promise = create(['foo', 'bar'], { maxProcesses: 1 });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(controllers[0].onFinish).not.toHaveBeenCalled();
+    expect(controllers[1].onFinish).not.toHaveBeenCalled();
+
+    processes[0].emit('close', 0, null);
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(controllers[0].onFinish).not.toHaveBeenCalled();
+    expect(controllers[1].onFinish).not.toHaveBeenCalled();
+
+    processes[1].emit('close', 0, null);
+    await promise;
+
+    expect(controllers[0].onFinish).toHaveBeenCalled();
+    expect(controllers[1].onFinish).toHaveBeenCalled();
+})

--- a/src/concurrently.spec.js
+++ b/src/concurrently.spec.js
@@ -86,7 +86,7 @@ it('runs commands with a name or prefix color', () => {
 
 it('passes commands wrapped from a controller to the next one', () => {
     const fakeCommand = createFakeCommand('banana', 'banana');
-    controllers[0].handle.mockReturnValue([fakeCommand]);
+    controllers[0].handle.mockReturnValue({ commands: [fakeCommand] });
 
     create(['echo']);
 

--- a/src/concurrently.spec.js
+++ b/src/concurrently.spec.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events');
 
 const createFakeCommand = require('./flow-control/fixtures/fake-command');
+const FakeHandler = require('./flow-control/fixtures/fake-handler');
 const concurrently = require('./concurrently');
 
 let spawn, kill, controllers, processes = [];
@@ -18,7 +19,7 @@ beforeEach(() => {
         return process;
     });
     kill = jest.fn();
-    controllers = [{ handle: jest.fn(arg => arg) }, { handle: jest.fn(arg => arg) }];
+    controllers = [new FakeHandler(), new FakeHandler()];
 });
 
 it('fails if commands is not an array', () => {

--- a/src/flow-control/base-handler.js
+++ b/src/flow-control/base-handler.js
@@ -1,2 +1,11 @@
 module.exports = class BaseHandler {
+    constructor(options = {}) {
+        const { logger } = options;
+
+        this.logger = logger;
+    }
+
+    handle(commands) {
+        return commands;
+    }
 };

--- a/src/flow-control/base-handler.js
+++ b/src/flow-control/base-handler.js
@@ -6,7 +6,7 @@ module.exports = class BaseHandler {
     }
 
     handle(commands) {
-        return commands;
+        return { commands };
     }
 
     /**

--- a/src/flow-control/base-handler.js
+++ b/src/flow-control/base-handler.js
@@ -6,11 +6,11 @@ module.exports = class BaseHandler {
     }
 
     handle(commands) {
-        return { commands };
+        return {
+            commands,
+            // an optional callback to call when all commands have finished
+            // (either successful or not)
+            onFinish: null,
+        };
     }
-
-    /**
-     * A hook called when all commands have finished (either successful or not).
-     */
-    onFinish() {}
 };

--- a/src/flow-control/base-handler.js
+++ b/src/flow-control/base-handler.js
@@ -8,4 +8,9 @@ module.exports = class BaseHandler {
     handle(commands) {
         return commands;
     }
+
+    /**
+     * A hook called when all commands have finished (either successful or not).
+     */
+    onFinish() {}
 };

--- a/src/flow-control/base-handler.js
+++ b/src/flow-control/base-handler.js
@@ -1,0 +1,2 @@
+module.exports = class BaseHandler {
+};

--- a/src/flow-control/fixtures/fake-handler.js
+++ b/src/flow-control/fixtures/fake-handler.js
@@ -4,7 +4,7 @@ module.exports = class FakeHandler extends BaseHandler {
     constructor() {
         super();
 
-        this.handle = jest.fn(commands => commands);
+        this.handle = jest.fn(commands => ({ commands }));
         this.onFinish = jest.fn();
     }
 };

--- a/src/flow-control/fixtures/fake-handler.js
+++ b/src/flow-control/fixtures/fake-handler.js
@@ -5,5 +5,6 @@ module.exports = class FakeHandler extends BaseHandler {
         super();
 
         this.handle = jest.fn(commands => commands);
+        this.onFinish = jest.fn();
     }
 };

--- a/src/flow-control/fixtures/fake-handler.js
+++ b/src/flow-control/fixtures/fake-handler.js
@@ -4,7 +4,10 @@ module.exports = class FakeHandler extends BaseHandler {
     constructor() {
         super();
 
-        this.handle = jest.fn(commands => ({ commands }));
+        this.handle = jest.fn(commands => ({
+            commands,
+            onFinish: this.onFinish,
+        }));
         this.onFinish = jest.fn();
     }
 };

--- a/src/flow-control/fixtures/fake-handler.js
+++ b/src/flow-control/fixtures/fake-handler.js
@@ -1,0 +1,9 @@
+const BaseHandler = require('../base-handler')
+
+module.exports = class FakeHandler extends BaseHandler {
+    constructor() {
+        super();
+
+        this.handle = jest.fn(commands => commands);
+    }
+};

--- a/src/flow-control/input-handler.js
+++ b/src/flow-control/input-handler.js
@@ -2,8 +2,9 @@ const Rx = require('rxjs');
 const { map } = require('rxjs/operators');
 
 const defaults = require('../defaults');
+const BaseHandler = require('./base-handler');
 
-module.exports = class InputHandler {
+module.exports = class InputHandler extends BaseHandler {
     constructor({ defaultInputTarget, inputStream, logger }) {
         this.defaultInputTarget = defaultInputTarget || defaults.defaultInputTarget;
         this.inputStream = inputStream;

--- a/src/flow-control/input-handler.js
+++ b/src/flow-control/input-handler.js
@@ -5,11 +5,12 @@ const defaults = require('../defaults');
 const BaseHandler = require('./base-handler');
 
 module.exports = class InputHandler extends BaseHandler {
-    constructor({ defaultInputTarget, inputStream, logger }) {
+    constructor({ defaultInputTarget, inputStream, pauseInputStreamOnFinish, logger }) {
         super({ logger });
 
         this.defaultInputTarget = defaultInputTarget || defaults.defaultInputTarget;
         this.inputStream = inputStream;
+        this.pauseInputStreamOnFinish = pauseInputStreamOnFinish !== false;
     }
 
     handle(commands) {
@@ -40,7 +41,7 @@ module.exports = class InputHandler extends BaseHandler {
     }
 
     onFinish() {
-        if (this.inputStream) {
+        if (this.inputStream && this.pauseInputStreamOnFinish) {
             // https://github.com/kimmobrunfeldt/concurrently/issues/252
             this.inputStream.pause();
         }

--- a/src/flow-control/input-handler.js
+++ b/src/flow-control/input-handler.js
@@ -6,9 +6,10 @@ const BaseHandler = require('./base-handler');
 
 module.exports = class InputHandler extends BaseHandler {
     constructor({ defaultInputTarget, inputStream, logger }) {
+        super({ logger });
+
         this.defaultInputTarget = defaultInputTarget || defaults.defaultInputTarget;
         this.inputStream = inputStream;
-        this.logger = logger;
     }
 
     handle(commands) {

--- a/src/flow-control/input-handler.js
+++ b/src/flow-control/input-handler.js
@@ -15,7 +15,7 @@ module.exports = class InputHandler extends BaseHandler {
 
     handle(commands) {
         if (!this.inputStream) {
-            return commands;
+            return { commands };
         }
 
         Rx.fromEvent(this.inputStream, 'data')
@@ -37,7 +37,7 @@ module.exports = class InputHandler extends BaseHandler {
                 }
             });
 
-        return commands;
+        return { commands };
     }
 
     onFinish() {

--- a/src/flow-control/input-handler.js
+++ b/src/flow-control/input-handler.js
@@ -38,4 +38,11 @@ module.exports = class InputHandler extends BaseHandler {
 
         return commands;
     }
+
+    onFinish() {
+        if (this.inputStream) {
+            // https://github.com/kimmobrunfeldt/concurrently/issues/252
+            this.inputStream.pause();
+        }
+    }
 };

--- a/src/flow-control/input-handler.js
+++ b/src/flow-control/input-handler.js
@@ -37,13 +37,14 @@ module.exports = class InputHandler extends BaseHandler {
                 }
             });
 
-        return { commands };
-    }
-
-    onFinish() {
-        if (this.inputStream && this.pauseInputStreamOnFinish) {
-            // https://github.com/kimmobrunfeldt/concurrently/issues/252
-            this.inputStream.pause();
-        }
+        return {
+            commands,
+            onFinish: () => {
+                if (this.pauseInputStreamOnFinish) {
+                    // https://github.com/kimmobrunfeldt/concurrently/issues/252
+                    this.inputStream.pause();
+                }
+            },
+        };
     }
 };

--- a/src/flow-control/input-handler.spec.js
+++ b/src/flow-control/input-handler.spec.js
@@ -93,10 +93,10 @@ it('logs error if command is not found', () => {
 it('pauses input stream when finished', () => {
     expect(inputStream.readableFlowing).toBeNull();
 
-    controller.handle(commands);
+    const { onFinish } = controller.handle(commands);
     expect(inputStream.readableFlowing).toBe(true);
 
-    controller.onFinish();
+    onFinish();
     expect(inputStream.readableFlowing).toBe(false);
 });
 
@@ -105,9 +105,9 @@ it('does not pause input stream when pauseInputStreamOnFinish is set to false', 
 
     expect(inputStream.readableFlowing).toBeNull();
 
-    controller.handle(commands);
+    const { onFinish } = controller.handle(commands);
     expect(inputStream.readableFlowing).toBe(true);
 
-    controller.onFinish();
+    onFinish();
     expect(inputStream.readableFlowing).toBe(true);
 });

--- a/src/flow-control/input-handler.spec.js
+++ b/src/flow-control/input-handler.spec.js
@@ -22,10 +22,10 @@ beforeEach(() => {
 });
 
 it('returns same commands', () => {
-    expect(controller.handle(commands)).toBe(commands);
+    expect(controller.handle(commands)).toMatchObject({ commands });
 
     controller = new InputHandler({ logger });
-    expect(controller.handle(commands)).toBe(commands);
+    expect(controller.handle(commands)).toMatchObject({ commands });
 });
 
 it('forwards input stream to default target ID', () => {

--- a/src/flow-control/input-handler.spec.js
+++ b/src/flow-control/input-handler.spec.js
@@ -89,3 +89,13 @@ it('logs error if command is not found', () => {
     expect(commands[1].stdin.write).not.toHaveBeenCalled();
     expect(logger.logGlobalEvent).toHaveBeenCalledWith('Unable to find command foobar, or it has no stdin open\n');
 });
+
+it('pauses input stream when finished', () => {
+    expect(inputStream.readableFlowing).toBeNull();
+
+    controller.handle(commands);
+    expect(inputStream.readableFlowing).toBe(true);
+
+    controller.onFinish();
+    expect(inputStream.readableFlowing).toBe(false);
+});

--- a/src/flow-control/input-handler.spec.js
+++ b/src/flow-control/input-handler.spec.js
@@ -99,3 +99,15 @@ it('pauses input stream when finished', () => {
     controller.onFinish();
     expect(inputStream.readableFlowing).toBe(false);
 });
+
+it('does not pause input stream when pauseInputStreamOnFinish is set to false', () => {
+    controller = new InputHandler({ inputStream, pauseInputStreamOnFinish: false });
+
+    expect(inputStream.readableFlowing).toBeNull();
+
+    controller.handle(commands);
+    expect(inputStream.readableFlowing).toBe(true);
+
+    controller.onFinish();
+    expect(inputStream.readableFlowing).toBe(true);
+});

--- a/src/flow-control/kill-on-signal.js
+++ b/src/flow-control/kill-on-signal.js
@@ -18,16 +18,18 @@ module.exports = class KillOnSignal extends BaseHandler {
             });
         });
 
-        return commands.map(command => {
-            const closeStream = command.close.pipe(map(exitInfo => {
-                const exitCode = caughtSignal === 'SIGINT' ? 0 : exitInfo.exitCode;
-                return Object.assign({}, exitInfo, { exitCode });
-            }));
-            return new Proxy(command, {
-                get(target, prop) {
-                    return prop === 'close' ? closeStream : target[prop];
-                }
-            });
-        });
+        return {
+            commands: commands.map(command => {
+                const closeStream = command.close.pipe(map(exitInfo => {
+                    const exitCode = caughtSignal === 'SIGINT' ? 0 : exitInfo.exitCode;
+                    return Object.assign({}, exitInfo, { exitCode });
+                }));
+                return new Proxy(command, {
+                    get(target, prop) {
+                        return prop === 'close' ? closeStream : target[prop];
+                    }
+                });
+            })
+        };
     }
 };

--- a/src/flow-control/kill-on-signal.js
+++ b/src/flow-control/kill-on-signal.js
@@ -4,6 +4,8 @@ const BaseHandler = require('./base-handler');
 
 module.exports = class KillOnSignal extends BaseHandler {
     constructor({ process }) {
+        super();
+
         this.process = process;
     }
 

--- a/src/flow-control/kill-on-signal.js
+++ b/src/flow-control/kill-on-signal.js
@@ -1,7 +1,8 @@
 const { map } = require('rxjs/operators');
 
+const BaseHandler = require('./base-handler');
 
-module.exports = class KillOnSignal {
+module.exports = class KillOnSignal extends BaseHandler {
     constructor({ process }) {
         this.process = process;
     }

--- a/src/flow-control/kill-on-signal.spec.js
+++ b/src/flow-control/kill-on-signal.spec.js
@@ -14,7 +14,7 @@ beforeEach(() => {
 });
 
 it('returns commands that keep non-close streams from original commands', () => {
-    const newCommands = controller.handle(commands);
+    const { commands: newCommands } = controller.handle(commands);
     newCommands.forEach((newCommand, i) => {
         expect(newCommand.close).not.toBe(commands[i].close);
         expect(newCommand.error).toBe(commands[i].error);
@@ -24,7 +24,7 @@ it('returns commands that keep non-close streams from original commands', () => 
 });
 
 it('returns commands that map SIGINT to exit code 0', () => {
-    const newCommands = controller.handle(commands);
+    const { commands: newCommands } = controller.handle(commands);
     expect(newCommands).not.toBe(commands);
     expect(newCommands).toHaveLength(commands.length);
 
@@ -40,7 +40,7 @@ it('returns commands that map SIGINT to exit code 0', () => {
 });
 
 it('returns commands that keep non-SIGINT exit codes', () => {
-    const newCommands = controller.handle(commands);
+    const { commands: newCommands } = controller.handle(commands);
     expect(newCommands).not.toBe(commands);
     expect(newCommands).toHaveLength(commands.length);
 

--- a/src/flow-control/kill-others.js
+++ b/src/flow-control/kill-others.js
@@ -5,7 +5,8 @@ const BaseHandler = require('./base-handler');
 
 module.exports = class KillOthers extends BaseHandler {
     constructor({ logger, conditions }) {
-        this.logger = logger;
+        super({ logger });
+
         this.conditions = _.castArray(conditions);
     }
 

--- a/src/flow-control/kill-others.js
+++ b/src/flow-control/kill-others.js
@@ -17,7 +17,7 @@ module.exports = class KillOthers extends BaseHandler {
         ));
 
         if (!conditions.length) {
-            return commands;
+            return { commands };
         }
 
         const closeStates = commands.map(command => command.close.pipe(
@@ -33,6 +33,6 @@ module.exports = class KillOthers extends BaseHandler {
             }
         }));
 
-        return commands;
+        return { commands };
     }
 };

--- a/src/flow-control/kill-others.js
+++ b/src/flow-control/kill-others.js
@@ -1,7 +1,9 @@
 const _ = require('lodash');
 const { filter, map } = require('rxjs/operators');
 
-module.exports = class KillOthers {
+const BaseHandler = require('./base-handler');
+
+module.exports = class KillOthers extends BaseHandler {
     constructor({ logger, conditions }) {
         this.logger = logger;
         this.conditions = _.castArray(conditions);

--- a/src/flow-control/kill-others.spec.js
+++ b/src/flow-control/kill-others.spec.js
@@ -20,8 +20,8 @@ const createWithConditions = conditions => new KillOthers({
 });
 
 it('returns same commands', () => {
-    expect(createWithConditions(['foo']).handle(commands)).toBe(commands);
-    expect(createWithConditions(['failure']).handle(commands)).toBe(commands);
+    expect(createWithConditions(['foo']).handle(commands)).toMatchObject({ commands });
+    expect(createWithConditions(['failure']).handle(commands)).toMatchObject({ commands });
 });
 
 it('does not kill others if condition does not match', () => {

--- a/src/flow-control/log-error.js
+++ b/src/flow-control/log-error.js
@@ -3,10 +3,6 @@ const { of } = require('rxjs');
 const BaseHandler = require('./base-handler');
 
 module.exports = class LogExit extends BaseHandler {
-    constructor({ logger }) {
-        this.logger = logger;
-    }
-
     handle(commands) {
         commands.forEach(command => command.error.subscribe(event => {
             this.logger.logCommandEvent(

--- a/src/flow-control/log-error.js
+++ b/src/flow-control/log-error.js
@@ -13,6 +13,6 @@ module.exports = class LogExit extends BaseHandler {
             this.logger.logCommandEvent(event.stack || event, command);
         }));
 
-        return commands;
+        return { commands };
     }
 };

--- a/src/flow-control/log-error.js
+++ b/src/flow-control/log-error.js
@@ -1,6 +1,8 @@
 const { of } = require('rxjs');
 
-module.exports = class LogExit {
+const BaseHandler = require('./base-handler');
+
+module.exports = class LogExit extends BaseHandler {
     constructor({ logger }) {
         this.logger = logger;
     }

--- a/src/flow-control/log-error.spec.js
+++ b/src/flow-control/log-error.spec.js
@@ -15,7 +15,7 @@ beforeEach(() => {
 });
 
 it('returns same commands', () => {
-    expect(controller.handle(commands)).toBe(commands);
+    expect(controller.handle(commands)).toMatchObject({ commands });
 });
 
 it('logs the error event of each command', () => {

--- a/src/flow-control/log-exit.js
+++ b/src/flow-control/log-exit.js
@@ -1,10 +1,6 @@
 const BaseHandler = require('./base-handler');
 
 module.exports = class LogExit extends BaseHandler {
-    constructor({ logger }) {
-        this.logger = logger;
-    }
-
     handle(commands) {
         commands.forEach(command => command.close.subscribe(({ exitCode }) => {
             this.logger.logCommandEvent(`${command.command} exited with code ${exitCode}`, command);

--- a/src/flow-control/log-exit.js
+++ b/src/flow-control/log-exit.js
@@ -6,6 +6,6 @@ module.exports = class LogExit extends BaseHandler {
             this.logger.logCommandEvent(`${command.command} exited with code ${exitCode}`, command);
         }));
 
-        return commands;
+        return { commands };
     }
 };

--- a/src/flow-control/log-exit.js
+++ b/src/flow-control/log-exit.js
@@ -1,4 +1,6 @@
-module.exports = class LogExit {
+const BaseHandler = require('./base-handler');
+
+module.exports = class LogExit extends BaseHandler {
     constructor({ logger }) {
         this.logger = logger;
     }

--- a/src/flow-control/log-exit.spec.js
+++ b/src/flow-control/log-exit.spec.js
@@ -15,7 +15,7 @@ beforeEach(() => {
 });
 
 it('returns same commands', () => {
-    expect(controller.handle(commands)).toBe(commands);
+    expect(controller.handle(commands)).toMatchObject({ commands });
 });
 
 it('logs the close event of each command', () => {

--- a/src/flow-control/log-output.js
+++ b/src/flow-control/log-output.js
@@ -7,6 +7,6 @@ module.exports = class LogOutput extends BaseHandler {
             command.stderr.subscribe(text => this.logger.logCommandText(text.toString(), command));
         });
 
-        return commands;
+        return { commands };
     }
 };

--- a/src/flow-control/log-output.js
+++ b/src/flow-control/log-output.js
@@ -1,10 +1,6 @@
 const BaseHandler = require('./base-handler');
 
 module.exports = class LogOutput extends BaseHandler {
-    constructor({ logger }) {
-        this.logger = logger;
-    }
-
     handle(commands) {
         commands.forEach(command => {
             command.stdout.subscribe(text => this.logger.logCommandText(text.toString(), command));

--- a/src/flow-control/log-output.js
+++ b/src/flow-control/log-output.js
@@ -1,4 +1,6 @@
-module.exports = class LogOutput {
+const BaseHandler = require('./base-handler');
+
+module.exports = class LogOutput extends BaseHandler {
     constructor({ logger }) {
         this.logger = logger;
     }

--- a/src/flow-control/log-output.spec.js
+++ b/src/flow-control/log-output.spec.js
@@ -15,7 +15,7 @@ beforeEach(() => {
 });
 
 it('returns same commands', () => {
-    expect(controller.handle(commands)).toBe(commands);
+    expect(controller.handle(commands)).toMatchObject({ commands });
 });
 
 it('logs the stdout of each command', () => {

--- a/src/flow-control/restart-process.js
+++ b/src/flow-control/restart-process.js
@@ -2,8 +2,9 @@ const Rx = require('rxjs');
 const { defaultIfEmpty, delay, filter, mapTo, skip, take, takeWhile } = require('rxjs/operators');
 
 const defaults = require('../defaults');
+const BaseHandler = require('./base-handler');
 
-module.exports = class RestartProcess {
+module.exports = class RestartProcess extends BaseHandler {
     constructor({ delay, tries, logger, scheduler }) {
         this.delay = +delay || defaults.restartDelay;
         this.tries = +tries || defaults.restartTries;

--- a/src/flow-control/restart-process.js
+++ b/src/flow-control/restart-process.js
@@ -6,10 +6,11 @@ const BaseHandler = require('./base-handler');
 
 module.exports = class RestartProcess extends BaseHandler {
     constructor({ delay, tries, logger, scheduler }) {
+        super({ logger });
+
         this.delay = +delay || defaults.restartDelay;
         this.tries = +tries || defaults.restartTries;
         this.tries = this.tries < 0 ? Infinity : this.tries;
-        this.logger = logger;
         this.scheduler = scheduler;
     }
 

--- a/src/flow-control/restart-process.spec.js
+++ b/src/flow-control/restart-process.spec.js
@@ -91,17 +91,17 @@ it('restarts processes until they succeed', () => {
 describe('returned commands', () => {
     it('are the same if 0 tries are to be attempted', () => {
         controller = new RestartProcess({ logger, scheduler });
-        expect(controller.handle(commands)).toBe(commands);
+        expect(controller.handle(commands)).toMatchObject({ commands });
     });
 
     it('are not the same, but with same length if 1+ tries are to be attempted', () => {
-        const newCommands = controller.handle(commands);
+        const { commands: newCommands } = controller.handle(commands);
         expect(newCommands).not.toBe(commands);
         expect(newCommands).toHaveLength(commands.length);
     });
 
     it('skip close events followed by restarts', () => {
-        const newCommands = controller.handle(commands);
+        const { commands: newCommands } = controller.handle(commands);
 
         const callback = jest.fn();
         newCommands[0].close.subscribe(callback);
@@ -120,7 +120,7 @@ describe('returned commands', () => {
     });
 
     it('keep non-close streams from original commands', () => {
-        const newCommands = controller.handle(commands);
+        const { commands: newCommands } = controller.handle(commands);
         newCommands.forEach((newCommand, i) => {
             expect(newCommand.close).not.toBe(commands[i].close);
             expect(newCommand.error).toBe(commands[i].error);


### PR DESCRIPTION
Fixes #252 by explicitly calling `.pause()` on the input stream after all commands have finished. This seems to be the only way to fix the problem, and there doesn't seem to be a way to reset the `process.stdin` state completely to the state before `concurrently` ran (see [NodeJS docs](https://nodejs.org/api/stream.html#stream_three_states)).

Refactored some parts of the code in order to make this change more drop-in:
* Added `BaseHandler` class that all handlers extend from
* Add `onFinish` to `BaseHandler` which runs after all commands have finished
* Add `FakeHandler` to tests that extend `BaseHandler` instead of ad-hoc handler objects in `concurrently.spec.js`
* Use an actual `Readable` in `input-handler` tests instead of `EventEmitter`

The CLI has not changed in this PR, but the programmatic API now has two new options:
* `handleInput`: an alias for the old `inputStream: process.stdin`. Just thought this would be nice, since 99% of the time, `inputStream` is set to `process.stdin`
* `pauseInputStreamOnFinish`: Some people might have a use-case where they want to read from `process.stdin` further after running `concurrently` programmatically. In this rare instance, they'd have to explicitly set this option to `false`, or explicitly call `process.stdin.resume()` afterwards. I can't imagine this being a common use-case, so I think this explicitness is a good trade-off.

## Repro steps

1. Write `start.js` as specified in #252, except replace `require('concurrently')` with `require('.')`. Put this file in the root of the repo.
2. `node start.js` + Ctrl-C should no longer hang / wait for Ctrl-D