### PR TITLE
Add pass arguments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ Restarting
       --restart-after  Delay time to respawn the process, in milliseconds.
                                                            [number] [default: 0]
 
+shorten command
+  -P, --prepend  prepend string to each command
+                                                          [string] [default: ""]
+  -A, --append   append string to each command
+                 eg: pass arguments                       [string] [default: ""]
+
 Options:
   -h, --help         Show help                                         [boolean]
   -v, -V, --version  Show version number                               [boolean]
@@ -192,6 +198,15 @@ Examples:
  - Custom prefix
 
      $ concurrently --prefix "{time}-{pid}" "npm run watch" "http-server"
+
+ - Custom cmd prepend
+
+     $ concurrently -P 'npm run' 'example:echo:A' 'example:echo:B'
+
+ - Custom cmd append
+
+     $ concurrently -A ' -- --watch' 'npm:example:echo*'
+     # Add one space to prevent yargs parse this string as an option
 
  - Custom names and colored prefixes
 

--- a/README.md
+++ b/README.md
@@ -176,10 +176,11 @@ Restarting
                                                            [number] [default: 0]
 
 shorten command
-  -P, --prepend  prepend string to each command
-                                                          [string] [default: ""]
+  -P, --prepend  prepend string to each command           [string] [default: ""]
   -A, --append   append string to each command
                  eg: pass arguments                       [string] [default: ""]
+  -D, --define   add definition to prepend / append each command, can be use
+                 multiple times                           [string] [default: []]
 
 Options:
   -h, --help         Show help                                         [boolean]
@@ -203,10 +204,14 @@ Examples:
 
      $ concurrently -P 'npm run' 'example:echo:A' 'example:echo:B'
 
+     $ concurrently -D prepend='npm run' 'example:echo:A' 'example:echo:B'
+
  - Custom cmd append
 
      $ concurrently -A ' -- --watch' 'npm:example:echo*'
      # Add one space to prevent yargs parse this string as an option
+
+     $ concurrently -D append='-- --watch' 'npm:example:echo*'
 
  - Custom names and colored prefixes
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,16 @@ Restarting
                                                            [number] [default: 0]
 
 shorten command
-  -P, --prepend  prepend string to each command           [string] [default: ""]
+  -P, --prepend  prepend string to each command
+                 but make sure you not using dash, else use
+                 `-D prepend="foobar"`                    [string] [default: ""]
   -A, --append   append string to each command
-                 eg: pass arguments                       [string] [default: ""]
-  -D, --define   add definition to prepend / append each command, can be use
-                 multiple times                           [string] [default: []]
+                 eg: pass arguments
+                 but make sure you not using dash, else use
+                 `-D append="foobar"`                     [string] [default: ""]
+  -D, --define   add definition to render
+                 template `{{prepend}} <command> {{append}}`
+                                                          [string] [default: []]
 
 Options:
   -h, --help         Show help                                         [boolean]

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -180,12 +180,17 @@ const args = yargs
 const prefixColors = args.prefixColors.split(',');
 const names = (args.names || '').split(args.nameSeparator);
 
+const _ObjectFromEntries = (l) => {
+    const d = {};
+    l.forEach(el=>d[el[0]] = el[1]);
+    return d;
+};
 const _define = Array.isArray(args.define) ? args.define : [args.define];
 const definition = Object.assign(
     {}, 
     { prepend: args.prepend, append: args.append },
     // desc: convert ["a=1","b=2"] into {"a":"1","b":"2"}
-    Object.fromEntries(
+    _ObjectFromEntries(
         _define
             .map(el=>el.split('='))
             .map(x=>[x[0],x.slice(1).join('=')])

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -187,8 +187,8 @@ const definition = Object.assign(
     // desc: convert ["a=1","b=2"] into {"a":"1","b":"2"}
     Object.fromEntries(
         _define
-        .map(el=>el.split('='))
-        .map(x=>[x[0],x.slice(1).join('=')])
+            .map(el=>el.split('='))
+            .map(x=>[x[0],x.slice(1).join('=')])
     )
 );
 

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -133,6 +133,20 @@ const args = yargs
                 'Identifier for child process to which input on stdin ' +
                 'should be sent if not specified at start of input.\n' +
                 'Can be either the index or the name of the process.'
+        },
+
+        // shorten command
+        'P': {
+            alias: 'prepend',
+            describe: 'prepend string to each command',
+            default: "",
+            type: 'string'
+        },
+        'A': {
+            alias: 'append',
+            describe: 'append string to each command',
+            default: "",
+            type: 'string'
         }
     })
     .group(['m', 'n', 'name-separator', 'raw', 's', 'no-color'], 'General')
@@ -153,6 +167,7 @@ concurrently(args._.map((command, index) => {
     lastColor = prefixColors[index] || lastColor;
     return {
         command,
+        argPend: { prepend:args.prepend, append:args.append },
         prefixColor: lastColor,
         name: names[index]
     };

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -140,7 +140,7 @@ const args = yargs
             alias: 'prepend',
             describe: 
                 'prepend string to each command',
-            default: "",
+            default: '',
             type: 'string'
         },
         'A': {
@@ -148,7 +148,7 @@ const args = yargs
             describe:
                 'append string to each command\n' + 
                 'eg: pass arguments',
-            default: "",
+            default: '',
             type: 'string'
         }
     })

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -138,13 +138,16 @@ const args = yargs
         // shorten command
         'P': {
             alias: 'prepend',
-            describe: 'prepend string to each command',
+            describe: 
+                'prepend string to each command',
             default: "",
             type: 'string'
         },
         'A': {
             alias: 'append',
-            describe: 'append string to each command',
+            describe:
+                'append string to each command\n' + 
+                'eg: pass arguments',
             default: "",
             type: 'string'
         }
@@ -154,6 +157,7 @@ const args = yargs
     .group(['i', 'default-input-target'], 'Input handling')
     .group(['k', 'kill-others-on-fail'], 'Killing other processes')
     .group(['restart-tries', 'restart-after'], 'Restarting')
+    .group(['P', 'A'], 'shorten command')
     // Too much text to write as JS strings, .txt file is better
     .epilogue(fs.readFileSync(__dirname + '/epilogue.txt', { encoding: 'utf8' }))
     .argv;

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -139,7 +139,9 @@ const args = yargs
         'P': {
             alias: 'prepend',
             describe: 
-                'prepend string to each command',
+                'prepend string to each command\n' +
+                'but make sure you not using dash, else use \n' +
+                '`-D prepend="foobar"`',
             default: '',
             type: 'string'
         },
@@ -147,7 +149,9 @@ const args = yargs
             alias: 'append',
             describe:
                 'append string to each command\n' + 
-                'eg: pass arguments',
+                'eg: pass arguments\n' +
+                'but make sure you not using dash, else use \n' +
+                '`-D append="foobar"`', 
             default: '',
             type: 'string'
         },

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -157,7 +157,8 @@ const args = yargs
         'D': {
             alias: 'define',
             describe: 
-                'add definition to prepend / append each command, can be use multiple times',
+                'add definition to render \n' + 
+                'template `{{prepend}} <command> {{append}}`',
             default: [],
             type: 'string'
         }

--- a/bin/epilogue.txt
+++ b/bin/epilogue.txt
@@ -15,11 +15,15 @@ Examples:
  - Custom cmd prepend
 
      $ $0 -P 'npm run' 'example:echo:A' 'example:echo:B'
+     
+     $ $0 -D prepend='npm run' 'example:echo:A' 'example:echo:B'
 
  - Custom cmd append
 
      $ $0 -A ' -- --watch' 'npm:example:echo*'
      # Add one space to prevent yargs parse this string as an option
+
+     $ $0 -D append='-- --watch' 'npm:example:echo*'
 
  - Custom names and colored prefixes
 

--- a/bin/epilogue.txt
+++ b/bin/epilogue.txt
@@ -12,6 +12,15 @@ Examples:
 
      $ $0 --prefix "{time}-{pid}" "npm run watch" "http-server"
 
+ - Custom cmd prepend
+
+     $ $0 -P 'npm run' 'example:echo:A' 'example:echo:B'
+
+ - Custom cmd append
+
+     $ $0 -A ' -- --watch' 'npm:example:echo*'
+     # Add one space to prevent yargs parse this string as an option
+
  - Custom names and colored prefixes
 
      $ $0 --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "http-server" "npm run watch"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "node": ">=10.0.0"
   },
   "scripts": {
+    "example:echo:A": "echo A",
+    "example:echo:B": "echo B",
     "lint": "eslint . --ignore-path .gitignore",
     "report-coverage": "cat coverage/lcov.info | coveralls",
     "test": "jest"

--- a/src/command-parser/zz-expand-arguments.js
+++ b/src/command-parser/zz-expand-arguments.js
@@ -2,12 +2,12 @@ module.exports = class StripQuotes {
     parse(commandInfo) {
         let { command } = commandInfo;
         const { argPend } = commandInfo;
-        if (!argPend) {
+        if (!argPend || !argPend.definition) {
             return commandInfo;
         }
 
-        const argPrepend = argPend.prepend ? (argPend.prepend + ' ') : '';
-        const argAppend = argPend.append ? (' ' + argPend.append) : '';
+        const argPrepend = argPend.definition.prepend ? (argPend.definition.prepend + ' ') : '';
+        const argAppend = argPend.definition.append ? (' ' + argPend.definition.append) : '';
         if (argPrepend === '' && argAppend === '') {
             return commandInfo;
         }

--- a/src/command-parser/zz-expand-arguments.js
+++ b/src/command-parser/zz-expand-arguments.js
@@ -1,17 +1,18 @@
 module.exports = class StripQuotes {
     parse(commandInfo) {
-        let { command, argPend } = commandInfo;
-        if(!argPend) {
-            return commandInfo
+        let { command } = commandInfo;
+        const { argPend } = commandInfo;
+        if (!argPend) {
+            return commandInfo;
         }
 
-        const argPrepend = argPend.prepend ? (argPend.prepend + " ") : ""
-        const argAppend = argPend.append ? (" " + argPend.append) : ""
-        if (argPrepend == "" && argAppend == "") {
-            return commandInfo
+        const argPrepend = argPend.prepend ? (argPend.prepend + ' ') : '';
+        const argAppend = argPend.append ? (' ' + argPend.append) : '';
+        if (argPrepend === '' && argAppend === '') {
+            return commandInfo;
         }
 
-        command = argPrepend + command + argAppend
+        command = argPrepend + command + argAppend;
         return Object.assign({}, commandInfo, { command });
     }
 };

--- a/src/command-parser/zz-expand-arguments.js
+++ b/src/command-parser/zz-expand-arguments.js
@@ -1,0 +1,17 @@
+module.exports = class StripQuotes {
+    parse(commandInfo) {
+        let { command, argPend } = commandInfo;
+        if(!argPend) {
+            return commandInfo
+        }
+
+        const argPrepend = argPend.prepend ? (argPend.prepend + " ") : ""
+        const argAppend = argPend.append ? (" " + argPend.append) : ""
+        if (argPrepend == "" && argAppend == "") {
+            return commandInfo
+        }
+
+        command = argPrepend + command + argAppend
+        return Object.assign({}, commandInfo, { command });
+    }
+};

--- a/src/command-parser/zz-expand-arguments.spec.js
+++ b/src/command-parser/zz-expand-arguments.spec.js
@@ -21,7 +21,7 @@ it('noop if empty argPend', () => {
 it('argPend prepend', () => {
     const commandInfo = {
         command: 'foo bar',
-        argPend: { prepend: "echo" },
+        argPend: { prepend: 'echo' },
     };
     expect(parser.parse(commandInfo).command)
         .toEqual('echo foo bar');
@@ -30,7 +30,7 @@ it('argPend prepend', () => {
 it('argPend append', () => {
     const commandInfo = {
         command: 'foo bar',
-        argPend: { append: "--watch" },
+        argPend: { append: '--watch' },
     };
     expect(parser.parse(commandInfo).command)
         .toEqual('foo bar --watch');
@@ -39,7 +39,7 @@ it('argPend append', () => {
 it('argPend prepend + append', () => {
     const commandInfo = {
         command: 'foo bar',
-        argPend: { prepend: "echo", append: "--watch" },
+        argPend: { prepend: 'echo', append: '--watch' },
     };
     expect(parser.parse(commandInfo).command)
         .toEqual('echo foo bar --watch');

--- a/src/command-parser/zz-expand-arguments.spec.js
+++ b/src/command-parser/zz-expand-arguments.spec.js
@@ -1,0 +1,46 @@
+const ZZ_ExpandArguments = require('./zz-expand-arguments');
+const parser = new ZZ_ExpandArguments();
+
+it('noop if no argPend', () => {
+    const commandInfo = {
+        command: 'foo bar'
+    };
+    expect(parser.parse(commandInfo).command)
+        .toEqual('foo bar');
+});
+
+it('noop if empty argPend', () => {
+    const commandInfo = {
+        command: 'foo bar',
+        argPend: {}
+    };
+    expect(parser.parse(commandInfo).command)
+        .toEqual('foo bar');
+});
+
+it('argPend prepend', () => {
+    const commandInfo = {
+        command: 'foo bar',
+        argPend: { prepend: "echo" },
+    };
+    expect(parser.parse(commandInfo).command)
+        .toEqual('echo foo bar');
+});
+
+it('argPend append', () => {
+    const commandInfo = {
+        command: 'foo bar',
+        argPend: { append: "--watch" },
+    };
+    expect(parser.parse(commandInfo).command)
+        .toEqual('foo bar --watch');
+});
+
+it('argPend prepend + append', () => {
+    const commandInfo = {
+        command: 'foo bar',
+        argPend: { prepend: "echo", append: "--watch" },
+    };
+    expect(parser.parse(commandInfo).command)
+        .toEqual('echo foo bar --watch');
+});

--- a/src/command-parser/zz-expand-arguments.spec.js
+++ b/src/command-parser/zz-expand-arguments.spec.js
@@ -12,7 +12,7 @@ it('noop if no argPend', () => {
 it('noop if empty argPend', () => {
     const commandInfo = {
         command: 'foo bar',
-        argPend: {}
+        argPend: { definition: {} }
     };
     expect(parser.parse(commandInfo).command)
         .toEqual('foo bar');
@@ -21,7 +21,7 @@ it('noop if empty argPend', () => {
 it('argPend prepend', () => {
     const commandInfo = {
         command: 'foo bar',
-        argPend: { prepend: 'echo' },
+        argPend: { definition: { prepend: 'echo' } },
     };
     expect(parser.parse(commandInfo).command)
         .toEqual('echo foo bar');
@@ -30,7 +30,7 @@ it('argPend prepend', () => {
 it('argPend append', () => {
     const commandInfo = {
         command: 'foo bar',
-        argPend: { append: '--watch' },
+        argPend: { definition: { append: '--watch' } },
     };
     expect(parser.parse(commandInfo).command)
         .toEqual('foo bar --watch');
@@ -39,7 +39,7 @@ it('argPend append', () => {
 it('argPend prepend + append', () => {
     const commandInfo = {
         command: 'foo bar',
-        argPend: { prepend: 'echo', append: '--watch' },
+        argPend: { definition: { prepend: 'echo', append: '--watch' } },
     };
     expect(parser.parse(commandInfo).command)
         .toEqual('echo foo bar --watch');

--- a/src/concurrently.js
+++ b/src/concurrently.js
@@ -6,7 +6,7 @@ const treeKill = require('tree-kill');
 const StripQuotes = require('./command-parser/strip-quotes');
 const ExpandNpmShortcut = require('./command-parser/expand-npm-shortcut');
 const ExpandNpmWildcard = require('./command-parser/expand-npm-wildcard');
-const ZZ_ExpandArguments = require('./command-parser/zz-expand-arguments')
+const ZZ_ExpandArguments = require('./command-parser/zz-expand-arguments');
 
 const CompletionListener = require('./completion-listener');
 

--- a/src/concurrently.js
+++ b/src/concurrently.js
@@ -6,6 +6,7 @@ const treeKill = require('tree-kill');
 const StripQuotes = require('./command-parser/strip-quotes');
 const ExpandNpmShortcut = require('./command-parser/expand-npm-shortcut');
 const ExpandNpmWildcard = require('./command-parser/expand-npm-wildcard');
+const ZZ_ExpandArguments = require('./command-parser/zz-expand-arguments')
 
 const CompletionListener = require('./completion-listener');
 
@@ -29,7 +30,8 @@ module.exports = (commands, options) => {
     const commandParsers = [
         new StripQuotes(),
         new ExpandNpmShortcut(),
-        new ExpandNpmWildcard()
+        new ExpandNpmWildcard(),
+        new ZZ_ExpandArguments(),
     ];
 
     commands = _(commands)
@@ -66,6 +68,7 @@ module.exports = (commands, options) => {
 function mapToCommandInfo(command) {
     return {
         command: command.command || command,
+        argPend: command.argPend,
         name: command.name || '',
         prefixColor: command.prefixColor || '',
         env: command.env || {},


### PR DESCRIPTION
[issue33](https://github.com/kimmobrunfeldt/concurrently/issues/33)

### Feature:
1. add prefix string to each command
2. add suffix string to each command

### Examples

Let `fd`/`find` feed files arguments to `concurrently`, instead of feed command arguments.

```sh
fd test.mjs directories \
    -X concurrently --kill-others-on-fail \
    -P node
```

```sh
concurrently --kill-others-on-fail \
    'node a1/test.mjs' \
    'node a2/test.mjs' \
    'node a3/test.mjs' \
    'node a4/test.mjs' \
    'node a5/test.mjs' \
    'node a6/test.mjs' \
    'node a7/test.mjs' \
    ...
```

```sh
fd serve.mjs directories \
    -X concurrently \
    -P node \
    -D append='--watch'
```

```sh
concurrently \
    'node a1/serve.mjs --watch' \
    'node a2/serve.mjs --watch' \
    'node a3/serve.mjs --watch' \
    'node a4/serve.mjs --watch' \
    'node a5/serve.mjs --watch' \
    'node a6/serve.mjs --watch' \
    'node a7/serve.mjs --watch' \
    ...
```