### PR TITLE
Add support for options in environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Examples:
      $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold"
      "http-server" "npm run watch"
 
+ - Configuring via environment variables with CONCURRENTLY_ prefix
+
+     $ CONCURRENTLY_RAW=true CONCURRENTLY_KILL_OTHERS=true $0 "echo hello" "echo world"
+
  - Send input to default
 
      $ concurrently --handle-input "nodemon" "npm run watch-js"

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -11,6 +11,7 @@ const args = yargs
     .version('v', require('../package.json').version)
     .alias('v', 'V')
     .alias('v', 'version')
+    // TODO: Add some tests for this.
     .env('CONCURRENTLY')
     .options({
         // General

--- a/bin/concurrently.js
+++ b/bin/concurrently.js
@@ -11,6 +11,7 @@ const args = yargs
     .version('v', require('../package.json').version)
     .alias('v', 'V')
     .alias('v', 'version')
+    .env('CONCURRENTLY')
     .options({
         // General
         'm': {

--- a/bin/epilogue.txt
+++ b/bin/epilogue.txt
@@ -16,6 +16,10 @@ Examples:
 
      $ $0 --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold" "http-server" "npm run watch"
 
+ - Configuring via environment variables with CONCURRENTLY_ prefix
+
+     $ CONCURRENTLY_RAW=true CONCURRENTLY_KILL_OTHERS=true $0 "echo hello" "echo world"
+
  - Send input to default
 
      $ $0 --handle-input "nodemon" "npm run watch-js"


### PR DESCRIPTION
This uses yargs' support for providing option values via the command line:  https://github.com/yargs/yargs/blob/main/docs/api.md#envprefix

My use case is that in CI scenarios I want raw output, but locally I want prefixes. I _could_ duplicate all the scripts in my package.json: one with `concurrently -r`, one without - but I feel that is suboptimal and could lead to mistakes when devs forget to keep them in sync.

With this change, my CI script can now look like:

```
set -eux
export CONCURRENTLY_RAW=true 

npm run check
npm run validate
npm run build-all
# etc..
```