### PR TITLE
Add command-{name|index} and !command-{name|index} condition to --success

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ General
                                - "last" for the last command to exit;
                                - "all" for all commands;
                                - "command-{name}"/"command-{index}" for the
-                               command with that name or index;
+                               commands with that name or index;
                                - "!command-{name}"/"!command-{index}" for all
-                               commands but the one with that name or index.
+                               commands but the ones with that name or index.
                                                                 [default: "all"]
   -r, --raw                    Output only raw output of processes, disables
                                prettifying and concurrently coloring.  [boolean]
-      --no-color               Disables colors from logging.           [boolean]
+      --no-color               Disables colors from logging            [boolean]
       --hide                   Comma-separated list of processes to hide the
                                output.
                                The processes can be identified by their name or

--- a/README.md
+++ b/README.md
@@ -148,11 +148,16 @@ General
                         "|"                                       [default: ","]
   -r, --raw             Output only raw output of processes, disables
                         prettifying and concurrently coloring.         [boolean]
-  -s, --success         Return exit code of zero or one based on the success or
-                        failure of the "first" child to terminate, the "last
-                        child", or succeed only if "all" child processes
-                        succeed.
-                              [choices: "first", "last", "all"] [default: "all"]
+  -s, --success         Which command(s) must exit with code 0 in order for
+                        concurrently exit with code 0 too. Options are:
+                        - "first" for the first command to exit;
+                        - "last" for the last command to exit;
+                        - "all" for all commands;
+                        - "command-{name}"/"command-{index}" for the command
+                        with that name or index;
+                        - "!command-{name}"/"!command-{index}" for all commands
+                        but the one with that name or index.
+                                                                [default: "all"]
       --no-color        Disables colors from logging                   [boolean]
       --hide            Comma-separated list of processes to hide the output.
                         The processes can be identified by their name or index.

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -53,8 +53,9 @@ const args = yargs(argsBeforeSep)
                 '- "first" for the first command to exit;\n' +
                 '- "last" for the last command to exit;\n' +
                 '- "all" for all commands;\n' +
-                '- "command-{name}"/"command-{index}" for the command with that name or index;\n' +
-                '- "!command-{name}"/"!command-{index}" for all commands but the one with that ' +
+                // Note: not a typo. Multiple commands can have the same name.
+                '- "command-{name}"/"command-{index}" for the commands with that name or index;\n' +
+                '- "!command-{name}"/"!command-{index}" for all commands but the ones with that ' +
                 'name or index.\n',
             default: defaults.success,
         },

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -38,10 +38,14 @@ const args = yargs
         'success': {
             alias: 's',
             describe:
-                'Return exit code of zero or one based on the success or failure ' +
-                'of the "first" child to terminate, the "last child", or succeed ' +
-                'only if "all" child processes succeed.',
-            choices: ['first', 'last', 'all'] as const,
+                'Which command(s) must exit with code 0 in order for concurrently exit with ' +
+                'code 0 too. Options are:\n' +
+                '- "first" for the first command to exit;\n' +
+                '- "last" for the last command to exit;\n' +
+                '- "all" for all commands;\n' +
+                '- "command-{name}"/"command-{index}" for the command with that name or index;\n' +
+                '- "!command-{name}"/"!command-{index}" for all commands but the one with that ' +
+                'name or index.\n',
             default: defaults.success,
         },
         'raw': {

--- a/src/completion-listener.spec.ts
+++ b/src/completion-listener.spec.ts
@@ -1,11 +1,16 @@
 import { TestScheduler } from 'rxjs/testing';
+import { CloseEvent } from './command';
 import { CompletionListener, SuccessCondition } from './completion-listener';
 import { createFakeCloseEvent, FakeCommand } from './fixtures/fake-command';
 
 let commands: FakeCommand[];
 let scheduler: TestScheduler;
 beforeEach(() => {
-    commands = [new FakeCommand('foo'), new FakeCommand('bar')];
+    commands = [
+        new FakeCommand('foo', 'echo', 0),
+        new FakeCommand('bar', 'echo', 1),
+        new FakeCommand('baz', 'echo', 2),
+    ];
     scheduler = new TestScheduler(() => true);
 });
 
@@ -15,12 +20,18 @@ const createController = (successCondition?: SuccessCondition) =>
         scheduler,
     });
 
+const emitFakeCloseEvent = (
+    command: FakeCommand,
+    event?: Partial<CloseEvent>,
+) => command.close.next(createFakeCloseEvent({ ...event, command, index: command.index }));
+
 describe('with default success condition set', () => {
     it('succeeds if all processes exited with code 0', () => {
         const result = createController().listen(commands);
 
         commands[0].close.next(createFakeCloseEvent({ exitCode: 0 }));
         commands[1].close.next(createFakeCloseEvent({ exitCode: 0 }));
+        commands[2].close.next(createFakeCloseEvent({ exitCode: 0 }));
 
         scheduler.flush();
 
@@ -32,6 +43,7 @@ describe('with default success condition set', () => {
 
         commands[0].close.next(createFakeCloseEvent({ exitCode: 0 }));
         commands[1].close.next(createFakeCloseEvent({ exitCode: 1 }));
+        commands[2].close.next(createFakeCloseEvent({ exitCode: 0 }));
 
         scheduler.flush();
 
@@ -45,6 +57,7 @@ describe('with success condition set to first', () => {
 
         commands[1].close.next(createFakeCloseEvent({ exitCode: 0 }));
         commands[0].close.next(createFakeCloseEvent({ exitCode: 1 }));
+        commands[2].close.next(createFakeCloseEvent({ exitCode: 1 }));
 
         scheduler.flush();
 
@@ -56,6 +69,7 @@ describe('with success condition set to first', () => {
 
         commands[1].close.next(createFakeCloseEvent({ exitCode: 1 }));
         commands[0].close.next(createFakeCloseEvent({ exitCode: 0 }));
+        commands[2].close.next(createFakeCloseEvent({ exitCode: 0 }));
 
         scheduler.flush();
 
@@ -69,6 +83,7 @@ describe('with success condition set to last', () => {
 
         commands[1].close.next(createFakeCloseEvent({ exitCode: 1 }));
         commands[0].close.next(createFakeCloseEvent({ exitCode: 0 }));
+        commands[2].close.next(createFakeCloseEvent({ exitCode: 0 }));
 
         scheduler.flush();
 
@@ -80,10 +95,73 @@ describe('with success condition set to last', () => {
 
         commands[1].close.next(createFakeCloseEvent({ exitCode: 0 }));
         commands[0].close.next(createFakeCloseEvent({ exitCode: 1 }));
+        commands[2].close.next(createFakeCloseEvent({ exitCode: 1 }));
 
         scheduler.flush();
 
         return expect(result).rejects.toEqual(expect.anything());
     });
 
+});
+
+describe.each([
+    // Use the middle command for both cases to make it more difficult to make a mess up
+    // in the implementation cause false passes.
+    ['command-bar' as const, 'bar'],
+    ['command-1' as const, 1],
+])('with success condition set to %s', (condition, nameOrIndex) => {
+    it(`succeeds if command ${nameOrIndex} exits with code 0`, () => {
+        const result = createController(condition).listen(commands);
+
+        emitFakeCloseEvent(commands[0], { exitCode: 1 });
+        emitFakeCloseEvent(commands[1], { exitCode: 0 });
+        emitFakeCloseEvent(commands[2], { exitCode: 1 });
+
+        scheduler.flush();
+
+        return expect(result).resolves.toEqual(expect.anything());
+    });
+
+    it(`fails if command ${nameOrIndex} exits with non-0 code`, () => {
+        const result = createController(condition).listen(commands);
+
+        emitFakeCloseEvent(commands[0], { exitCode: 0 });
+        emitFakeCloseEvent(commands[1], { exitCode: 1 });
+        emitFakeCloseEvent(commands[2], { exitCode: 0 });
+
+        scheduler.flush();
+
+        return expect(result).rejects.toEqual(expect.anything());
+    });
+});
+
+describe.each([
+    // Use the middle command for both cases to make it more difficult to make a mess up
+    // in the implementation cause false passes.
+    ['!command-bar' as const, 'bar'],
+    ['!command-1' as const, 1],
+])('with success condition set to %s', (condition, nameOrIndex) => {
+    it(`succeeds if all commands but ${nameOrIndex} exit with code 0`, () => {
+        const result = createController(condition).listen(commands);
+
+        emitFakeCloseEvent(commands[0], { exitCode: 0 });
+        emitFakeCloseEvent(commands[1], { exitCode: 1 });
+        emitFakeCloseEvent(commands[2], { exitCode: 0 });
+
+        scheduler.flush();
+
+        return expect(result).resolves.toEqual(expect.anything());
+    });
+
+    it(`fails if any commands but ${nameOrIndex} exit with non-0 code`, () => {
+        const result = createController(condition).listen(commands);
+
+        emitFakeCloseEvent(commands[0], { exitCode: 1 });
+        emitFakeCloseEvent(commands[1], { exitCode: 1 });
+        emitFakeCloseEvent(commands[2], { exitCode: 0 });
+
+        scheduler.flush();
+
+        return expect(result).rejects.toEqual(expect.anything());
+    });
 });

--- a/src/completion-listener.spec.ts
+++ b/src/completion-listener.spec.ts
@@ -122,6 +122,19 @@ describe.each([
         return expect(result).resolves.toEqual(expect.anything());
     });
 
+    it(`succeeds if all commands ${nameOrIndex} exit with code 0`, () => {
+        commands = [commands[0], commands[1], commands[1]];
+        const result = createController(condition).listen(commands);
+
+        emitFakeCloseEvent(commands[0], { exitCode: 1 });
+        emitFakeCloseEvent(commands[1], { exitCode: 0 });
+        emitFakeCloseEvent(commands[2], { exitCode: 0 });
+
+        scheduler.flush();
+
+        return expect(result).resolves.toEqual(expect.anything());
+    });
+
     it(`fails if command ${nameOrIndex} exits with non-0 code`, () => {
         const result = createController(condition).listen(commands);
 
@@ -132,6 +145,19 @@ describe.each([
         scheduler.flush();
 
         return expect(result).rejects.toEqual(expect.anything());
+    });
+
+    it(`fails if some commands ${nameOrIndex} exit with non-0 code`, () => {
+        commands = [commands[0], commands[1], commands[1]];
+        const result = createController(condition).listen(commands);
+
+        emitFakeCloseEvent(commands[0], { exitCode: 1 });
+        emitFakeCloseEvent(commands[1], { exitCode: 0 });
+        emitFakeCloseEvent(commands[2], { exitCode: 1 });
+
+        scheduler.flush();
+
+        return expect(result).resolves.toEqual(expect.anything());
     });
 
     it(`fails if command ${nameOrIndex} doesn't exist`, () => {

--- a/src/completion-listener.spec.ts
+++ b/src/completion-listener.spec.ts
@@ -133,6 +133,15 @@ describe.each([
 
         return expect(result).rejects.toEqual(expect.anything());
     });
+
+    it(`fails if command ${nameOrIndex} doesn't exist`, () => {
+        const result = createController(condition).listen([commands[0]]);
+
+        emitFakeCloseEvent(commands[0], { exitCode: 0 });
+        scheduler.flush();
+
+        return expect(result).rejects.toEqual(expect.anything());
+    });
 });
 
 describe.each([
@@ -163,5 +172,14 @@ describe.each([
         scheduler.flush();
 
         return expect(result).rejects.toEqual(expect.anything());
+    });
+
+    it(`succeeds if command ${nameOrIndex} doesn't exist`, () => {
+        const result = createController(condition).listen([commands[0]]);
+
+        emitFakeCloseEvent(commands[0], { exitCode: 0 });
+        scheduler.flush();
+
+        return expect(result).resolves.toEqual(expect.anything());
     });
 });

--- a/src/completion-listener.ts
+++ b/src/completion-listener.ts
@@ -44,17 +44,20 @@ export class CompletionListener {
         } else if (this.successCondition === 'last') {
             return events[events.length - 1].exitCode === 0;
         } else if (!/^!?command-.+$/.test(this.successCondition)) {
-            // If not a `command-` syntax, then it's an 'all' condition.
+            // If not a `command-` syntax, then it's an 'all' condition or it's treated as such.
             return events.every(({ exitCode }) => exitCode === 0);
         }
 
+        // Check `command-` syntax condition
         const [, nameOrIndex] = this.successCondition.split('-');
         const targetCommandEvent = events.find(({ command, index }) => (
             command.name === nameOrIndex
             || index === Number(nameOrIndex)
         ));
         return this.successCondition.startsWith('!')
+            // All commands except the specified one must exit succesfully
             ? events.every((event) => event === targetCommandEvent || event.exitCode === 0)
+            // Only the specified command must exit succesfully
             : targetCommandEvent && targetCommandEvent.exitCode === 0;
     }
 

--- a/src/completion-listener.ts
+++ b/src/completion-listener.ts
@@ -8,8 +8,8 @@ import { CloseEvent, Command } from './command';
  * - `first`: only the first specified command;
  * - `last`: only the last specified command;
  * - `all`: all commands.
- * - `command-{name|index}`: only the command with the specified name or index.
- * - `!command-{name|index}`: all commands but the one with the specified name or index.
+ * - `command-{name|index}`: only the commands with the specified names or index.
+ * - `!command-{name|index}`: all commands but the ones with the specified names or index.
  */
 export type SuccessCondition = 'first' | 'last' | 'all' | `command-${string|number}` | `!command-${string|number}`;
 


### PR DESCRIPTION
Implements 2 (or 4?) new possible conditions for `--success` flag:
- `command-{name|index}`: command with the specified name or index must exit with 0;
- `!command-{name|index}`: all but the command with the specified name or index must exit with 0.

I think that it expanding the use of `!` to `!first` and `!last` could come next, but for now that's an advanced enough solution!

Closes #280.
Related: #281