### PR TITLE
Limit workflow triggers & update actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,13 @@
 name: Tests
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 env:
   CI: true
 
@@ -16,10 +24,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Set Node.js version
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 


### PR DESCRIPTION
Limit the test workflow to only run on push events on master branch and pull requests which do target the master branch.

Ensures the workflow is not triggered twice on a pull request as we can see, for example, in the following picture:

<img width="600" alt="Screenshot 2022-05-09 at 13 34 18" src="https://user-images.githubusercontent.com/5363448/167401761-485bb1e6-f6ff-402b-86e3-a5f0fb55a8cc.png">

Also update the `checkout` and `setup-node` actions to their latest versions.