### PR TITLE
Update rxjs to version 7.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "chalk": "^4.1.0",
         "date-fns": "^2.16.1",
         "lodash": "^4.17.21",
-        "rxjs": "^6.6.3",
+        "rxjs": "^7.0.0",
         "shell-quote": "^1.7.3",
         "spawn-command": "^0.0.2-1",
         "supports-color": "^8.1.0",
@@ -4667,15 +4667,17 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
+    },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -5151,7 +5153,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -9018,11 +9021,18 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
+      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
       "requires": {
-        "tslib": "^1.9.0"
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
       }
     },
     "safe-buffer": {
@@ -9357,7 +9367,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "chalk": "^4.1.0",
     "date-fns": "^2.16.1",
     "lodash": "^4.17.21",
-    "rxjs": "^6.6.3",
+    "rxjs": "^7.0.0",
     "shell-quote": "^1.7.3",
     "spawn-command": "^0.0.2-1",
     "supports-color": "^8.1.0",

--- a/src/completion-listener.ts
+++ b/src/completion-listener.ts
@@ -75,16 +75,14 @@ export class CompletionListener {
      */
     listen(commands: Command[]): Promise<CloseEvent[]> {
         const closeStreams = commands.map(command => command.close);
-        return Rx.merge(...closeStreams)
+        return Rx.lastValueFrom(Rx.merge(...closeStreams)
             .pipe(
                 bufferCount(closeStreams.length),
                 switchMap(exitInfos =>
                     this.isSuccess(exitInfos)
                         ? Rx.of(exitInfos, this.scheduler)
-                        : Rx.throwError(exitInfos, this.scheduler),
-                ),
+                        : Rx.throwError(exitInfos, this.scheduler)),
                 take(1),
-            )
-            .toPromise();
+            ));
     }
 };

--- a/src/flow-control/log-timings.spec.ts
+++ b/src/flow-control/log-timings.spec.ts
@@ -99,7 +99,7 @@ it('does not log timings summary if there was an error', () => {
     controller.handle(commands);
 
     commands[0].close.next(command0ExitInfo);
-    commands[1].error.next();
+    commands[1].error.next(undefined);
 
     expect(logger.logTable).toHaveBeenCalledTimes(0);
 


### PR DESCRIPTION
This pull request was created using the JSFIX tool (https://jsfix.live) by Coana.tech (https://coana.tech).
It bumps rxjs to version 7.0.0.

<strong>Sign up your project [here](https://jsfix.live/scanner) to receive notifications about other packages updates JSFIX can help with.</strong>

***

<h3> Pull request details</h3>

<details open><summary><strong> 🚧 - Manual review items (please check before merge)</strong></summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes not automatically fixable by JSFIX.</summary><blockquote class="pr-blockquote">

<details open>
<summary>General breaking changes (not related to specific API usages in your code).</summary>

* onUnhandledError: Errors that occur during setup of an observable subscription, after the subscription has emitted an error, or completed will now throw in their own call stack. Before it would call console.warn. This is potentially breaking in edge cases for node applications, which may be configured to terminate for unhandled exceptions. In the unlikely event this affects you, you can configure the behavior to console.warn in the new configuration setting like so: import { config } from 'rxjs'; config.onUnhandledError = (err) => console.warn(err);
* TS: RxJS requires TS 4.2
* RxJS Error types Tests that are written with naive expectations against errors may fail now that errors have a proper stack property. In some testing frameworks, a deep equality check on two error instances will check the values in stack, which could be different.
</details>

<details open>
<summary>The following breaking changes are unlikely to affect your code. Below each bullet is listed the dependency usages detected by JSFIX that may be affected by the breaking change.</summary>



* map: thisArg will now default to undefined. The previous default of MapSubscriber never made any sense. This will only affect code that calls map with a function and references this like so: source.pipe(map(function () { console.log(this); })). There wasn't anything useful about doing this, so the breakage is expected to be very minimal. If anything we're no longer leaking an implementation detail.
  - [bin/concurrently.spec.ts#L43-L43](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-ce4819f3a3e904124bb6256289004f1f68d330d2a7bde4a85658f32263014b72L43-L43)
  - [src/flow-control/input-handler.ts#L42-L42](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-1b93a742e237d69e53ad36e2124b4ccf9ab1fa44a3f10dcdee11d3bb8539d60dL42-L42)
  - [src/flow-control/kill-on-signal.ts#L28-L31](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-4b65b41e57c1fdeaf8e2a7562791ffd13b0ea351d4b9f2db9739163dfc6aec52L28-L31)
  - [src/flow-control/kill-others.ts#L36-L36](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-94fbd40770d337884835c482e7707c0400c605ac3b809eb37431aa890637a006L36-L36)
* take and will now throw runtime error for arguments that are negative or NaN, this includes non-TS calls like take().
  - [src/completion-listener.ts#L86-L86](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-ffc6929f17eed611098617418c0d84422929a6b230c1fa8f61a33a0122b26c74L86-L86)
  - [src/flow-control/log-timings.ts#L79-L79](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-b64de96d4b163fcb00e8420d51cea1e3bd7f8e5aa9ccf476dfde428587597259L79-L79)
  - [src/flow-control/restart-process.ts#L36-L36](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-70857a97d3d6986b5831383f4ed468d6efe594f35386684419a94d29062090baL36-L36)
* throwError: In an extreme corner case for usage, throwError is no longer able to emit a function as an error directly. If you need to push a function as an error, you will have to use the factory function to return the function like so: throwError(() => functionToEmit), in other words throwError(() => () => console.log('called later')).
  - [src/completion-listener.ts#L84-L84](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-ffc6929f17eed611098617418c0d84422929a6b230c1fa8f61a33a0122b26c74L84-L84)
</details>

</blockquote></details>

</blockquote></details><details><summary>Additional details</summary><blockquote class="pr-blockquote"><details>
<summary>Breaking changes where JSFIX patched all occurrences.</summary>

* toPromise: toPromise return type now returns T | undefined in TypeScript, which is correct, but may break builds.
  - [src/completion-listener.ts#L78-L88](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-ffc6929f17eed611098617418c0d84422929a6b230c1fa8f61a33a0122b26c74L78-L88)<br><br>
* Calling .next on a Subject without passing a value is no longer allowed
  - [src/flow-control/log-timings.spec.ts#L102-L102](https://github.com/open-cli-tools/concurrently/pull/326/commits/2eeee42f6fc3f012b0a867fcced8edb7b458d876#diff-171aae75d1dc9b0956e8fafe21634d69ef8aeae69e2b404bf7b46e0519503290L102-L102)</details>

<details>
<summary>Breaking changes where JSFIX found that there were no occurrences.</summary>

* Subscription: add no longer returns an unnecessary Subscription reference. This was done to prevent confusion caused by a legacy behavior. You can now add and remove functions and Subscriptions as teardowns to and from a Subscription using add and remove directly. Before this, remove only accepted subscriptions.
* Subscriber: new Subscriber no longer takes 0-3 arguments. To create a Subscriber with 0-3 arguments, use Subscriber.create. However, please note that there is little to no reason that you should be creating Subscriber references directly, and Subscriber.create and new Subscriber are both deprecated.
* Leaked implementation detail _unsubscribeAndRecycle of Subscriber has been removed. Just use new Subscription objects
* ReplaySubject no longer schedules emissions when a scheduler is provided. If you need that behavior, please compose in observeOn using pipe, for example: new ReplaySubject(2, 3000).pipe(observeOn(asap))
* rxjs-compat: rxjs/Rx is no longer a valid import site.
* The static sortActions method on VirtualTimeScheduler is no longer publicly exposed by our TS types.
* Notification.createNext(undefined) will no longer return the exact same reference everytime.
* race: race() will no longer subscribe to subsequent observables if a provided source synchronously errors or completes. This means side effects that might have occurred during subscription in those rare cases will no longer occur.
* unsubscribe no longer available via the this context of observer functions. To reenable, set config.useDeprecatedNextContext = true on the rxjs config found at import { config } from 'rxjs';. Note that enabling this will result in a performance penalty for all consumer subscriptions.
* defer no longer allows factories to return void or undefined. All factories passed to defer must return a proper ObservableInput, such as Observable, Promise, et al. To get the same behavior as you may have relied on previously, return EMPTY or return of() from the factory.
* mergeScan: mergeScan will no longer emit its inner state again upon completion.
* single operator will now throw for scenarios where values coming in are either not present, or do not match the provided predicate. Error types thrown have also been updated, please check documentation for changes.
* An undocumented behavior where passing a negative count argument to repeat would result in an observable that repeats forever.
* Removed an undocumented behavior where passing a negative count argument to retry would result in an observable that repeats forever.
* skipLast: skipLast will no longer error when passed a negative number, rather it will simply return the source, as though 0 was passed.
* takeLast now has runtime assertions that throw TypeErrors for invalid arguments. Calling takeLast without arguments or with an argument that is NaN will throw a TypeError
* zip: zip operators will no longer iterate provided iterables "as needed", instead the iterables will be treated as push-streams just like they would be everywhere else in RxJS. This means that passing an endless iterable will result in the thread locking up, as it will endlessly try to read from that iterable. This puts us in-line with all other Rx implementations. To work around this, it is probably best to use map or some combination of map and zip. For example, zip(source$, iterator) could be source$.pipe(map(value => [value, iterator.next().value])).
* zip: Zipping a single array will now have a different result. This is an extreme corner-case, because it is very unlikely that anyone would want to zip an array with nothing at all. The workaround would be to wrap the array in another array zip([[1,2,3]]). But again, that's pretty weird.
* ajax body serialization will now use default XHR behavior in all cases. If the body is a Blob, ArrayBuffer, any array buffer view (like a byte sequence, e.g. Uint8Array, etc), FormData, URLSearchParams, string, or ReadableStream, default handling is use. If the body is otherwise typeof "object", then it will be converted to JSON via JSON.stringify, and the Content-Type header will be set to application/json;charset=utf-8. All other types will emit an error.
* The Content-Type header passed to ajax configuration no longer has any effect on the serialization behavior of the AJAX request.
* ajax: In an extreme corner-case... If an error occurs, the responseType is "json", we're in IE, and the responseType is not valid JSON, the ajax observable will no longer emit a syntax error, rather it will emit a full AjaxError with more details.
* ajax: Ajax implementation drops support for IE10 and lower. This puts us in-line with other implementations and helps clean up code in this area
* some internal modules are no longer exported (not described in changelog)
* pairs: pairs will no longer function in IE without a polyfill for Object.entries. pairs itself is also deprecated in favor of users just using from(Object.entries(obj)).
* count: No longer passes source observable as a third argument to the predicate. 
That feature was rarely used, and of limited value. 
The workaround is to simply close over the source inside of the function if you need to access it in there.
</details>

</blockquote></details>

***

If you would like to provide feedback to the JSFIX developers, then please leave a comment on this pull request.