### PR TITLE
Fix TypeScript not able to resolve types when set to Node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "exports": {
     "import": "./index.mjs",
     "require": "./index.js",
-    "default": "./index.js"
+    "default": "./index.js",
+    "types": "./dist/src/index.d.ts"
   },
   "scripts": {
     "build": "tsc --build",


### PR DESCRIPTION
Fix for this error when using TypeScript 4.7 set to Node16 module resolution.

![image](https://user-images.githubusercontent.com/30204280/173592483-8ba271c1-2014-402a-8fdb-78ff27e72d76.png)
