### PR TITLE
Enhance tests

### DIFF
--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -176,7 +176,7 @@ export function concurrently(
     );
     commands = handleResult.commands;
 
-    if (options.logger) {
+    if (options.logger && options.outputStream) {
         const outputWriter = new OutputWriter({
             outputStream: options.outputStream,
             group: options.group,

--- a/src/flow-control/log-timings.spec.ts
+++ b/src/flow-control/log-timings.spec.ts
@@ -109,20 +109,14 @@ it('does not log timings summary if there was an error', () => {
 });
 
 it('logs the sorted timings summary when all processes close successfully', () => {
-    jest.spyOn(controller, 'printExitInfoTimingTable');
     controller.handle(commands);
 
     commands[0].close.next(command0ExitInfo);
     commands[1].close.next(command1ExitInfo);
 
+    expect(logger.logGlobalEvent).toHaveBeenCalledTimes(1);
+    expect(logger.logGlobalEvent).toHaveBeenCalledWith('Timings:');
     expect(logger.logTable).toHaveBeenCalledTimes(1);
-
-    // un-sorted ie by finish order
-    expect(controller.printExitInfoTimingTable).toHaveBeenCalledWith([
-        command0ExitInfo,
-        command1ExitInfo,
-    ]);
-
     // sorted by duration
     expect(logger.logTable).toHaveBeenCalledWith([
         LogTimings.mapCloseEventToTimingInfo(command1ExitInfo),

--- a/src/flow-control/log-timings.ts
+++ b/src/flow-control/log-timings.ts
@@ -51,15 +51,15 @@ export class LogTimings implements FlowController {
         this.timestampFormat = timestampFormat;
     }
 
-    printExitInfoTimingTable(exitInfos: CloseEvent[]) {
+    private printExitInfoTimingTable(exitInfos: CloseEvent[]) {
         const exitInfoTable = _(exitInfos)
             .sortBy(({ timings }) => timings.durationSeconds)
             .reverse()
             .map(LogTimings.mapCloseEventToTimingInfo)
             .value();
 
-        this.logger?.logGlobalEvent('Timings:');
-        this.logger?.logTable(exitInfoTable);
+        this.logger.logGlobalEvent('Timings:');
+        this.logger.logTable(exitInfoTable);
         return exitInfos;
     }
 
@@ -73,14 +73,14 @@ export class LogTimings implements FlowController {
             command.timer.subscribe(({ startDate, endDate }) => {
                 if (!endDate) {
                     const formattedStartDate = formatDate(startDate, this.timestampFormat);
-                    this.logger?.logCommandEvent(
+                    this.logger.logCommandEvent(
                         `${command.command} started at ${formattedStartDate}`,
                         command
                     );
                 } else {
                     const durationMs = endDate.getTime() - startDate.getTime();
                     const formattedEndDate = formatDate(endDate, this.timestampFormat);
-                    this.logger?.logCommandEvent(
+                    this.logger.logCommandEvent(
                         `${
                             command.command
                         } stopped at ${formattedEndDate} after ${durationMs.toLocaleString()}ms`,


### PR DESCRIPTION
* Enhance the test for the logger option in `concurrently` as suggested by @gustavohenke in https://github.com/open-cli-tools/concurrently/pull/334#discussion_r906512429
  * While working on this test, I realized that we should extend the corresponding if statement with a check for `outputStream`, since it doesn't make sense to pass the log to the `OutputWriter` if there is no output stream.
* Increase coverage on Node.js 12 (we get a score of 💯 with this) by ensuring the `logger` is always defined in the `LogTimings` class.
  For this I marked the `printExitInfoTimingTable` method as private... @gustavohenke Do you think this would be a breaking change?