### PR TITLE
feat: add shorthand `conc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ npm install concurrently --save
 
 ## Usage
 
-`concurrently` has an alias `conc`. I use conc throughout the following, but you can always replace `conc` with `concurrently`
+> **Note**
+> The `concurrently` command is now also available under the shorthand alias `conc`.
 
 Remember to surround separate commands with quotes:
 
 ```bash
-conc "command1 arg" "command2 arg"
+concurrently "command1 arg" "command2 arg"
 ```
 
 Otherwise **concurrently** would try to run 4 separate commands:
@@ -71,16 +72,16 @@ Otherwise **concurrently** would try to run 4 separate commands:
 In package.json, escape quotes:
 
 ```bash
-"start": "conc \"command1 arg\" \"command2 arg\""
+"start": "concurrently \"command1 arg\" \"command2 arg\""
 ```
 
 NPM run commands can be shortened:
 
 ```bash
-conc "npm:watch-js" "npm:watch-css" "npm:watch-node"
+concurrently "npm:watch-js" "npm:watch-css" "npm:watch-node"
 
 # Equivalent to:
-conc -n watch-js,watch-css,watch-node "npm run watch-js" "npm run watch-css" "npm run watch-node"
+concurrently -n watch-js,watch-css,watch-node "npm run watch-js" "npm run watch-css" "npm run watch-node"
 ```
 
 NPM shortened commands also support wildcards. Given the following scripts in
@@ -101,17 +102,17 @@ package.json:
 ```
 
 ```bash
-conc "npm:watch-*"
+concurrently "npm:watch-*"
 
 # Equivalent to:
-conc -n js,css,node "npm run watch-js" "npm run watch-css" "npm run watch-node"
+concurrently -n js,css,node "npm run watch-js" "npm run watch-css" "npm run watch-node"
 
 # Any name provided for the wildcard command will be used as a prefix to the wildcard
 # part of the script name:
-conc -n w: npm:watch-*
+concurrently -n w: npm:watch-*
 
 # Equivalent to:
-conc -n w:js,w:css,w:node "npm run watch-js" "npm run watch-css" "npm run watch-node"
+concurrently -n w:js,w:css,w:node "npm run watch-js" "npm run watch-css" "npm run watch-node"
 ```
 
 Exclusion is also supported. Given the following scripts in package.json:
@@ -133,7 +134,7 @@ Exclusion is also supported. Given the following scripts in package.json:
 ```bash
 # Running only lint:js and lint:ts
 #   with lint:fix:js and lint:fix:ts excluded
-conc "npm:lint:*(!fix)"
+concurrently "npm:lint:*(!fix)"
 ```
 
 Good frontend one-liner example [here](https://github.com/kimmobrunfeldt/dont-copy-paste-this-frontend-template/blob/5cd2bde719654941bdfc0a42c6f1b8e69ae79980/package.json#L9).
@@ -141,7 +142,7 @@ Good frontend one-liner example [here](https://github.com/kimmobrunfeldt/dont-co
 Help:
 
 ```
-conc [options] <command ...>
+concurrently [options] <command ...>
 
 General
   -m, --max-processes          How many processes should run at once.
@@ -151,8 +152,8 @@ General
                                template.
                                Example names: "main,browser,server"     [string]
       --name-separator         The character to split <names> on. Example usage:
-                               conc -n "styles|scripts|server"
-                               --name-separator "|"               [default: ","]
+                               -n "styles|scripts|server" --name-separator "|"
+                                                                  [default: ","]
   -s, --success                Which command(s) must exit with code 0 in order
                                for concurrently exit with code 0 too. Options
                                are:
@@ -234,65 +235,65 @@ Examples:
 
  - Output nothing more than stdout+stderr of child processes
 
-     $ conc --raw "npm run watch-less" "npm run watch-js"
+     $ concurrently --raw "npm run watch-less" "npm run watch-js"
 
  - Normal output but without colors e.g. when logging to file
 
-     $ conc --no-color "grunt watch" "http-server" > log
+     $ concurrently --no-color "grunt watch" "http-server" > log
 
  - Custom prefix
 
-     $ conc --prefix "{time}-{pid}" "npm run watch" "http-server"
+     $ concurrently --prefix "{time}-{pid}" "npm run watch" "http-server"
 
  - Custom names and colored prefixes
 
-     $ conc --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold"
+     $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold"
      "http-server" "npm run watch"
 
  - Configuring via environment variables with CONCURRENTLY_ prefix
 
-     $ CONCURRENTLY_RAW=true CONCURRENTLY_KILL_OTHERS=true conc "echo
+     $ CONCURRENTLY_RAW=true CONCURRENTLY_KILL_OTHERS=true concurrently "echo
      hello" "echo world"
 
  - Send input to default
 
-     $ conc --handle-input "nodemon" "npm run watch-js"
+     $ concurrently --handle-input "nodemon" "npm run watch-js"
      rs  # Sends rs command to nodemon process
 
  - Send input to specific child identified by index
 
-     $ conc --handle-input "npm run watch-js" nodemon
+     $ concurrently --handle-input "npm run watch-js" nodemon
      1:rs
 
  - Send input to specific child identified by name
 
-     $ conc --handle-input -n js,srv "npm run watch-js" nodemon
+     $ concurrently --handle-input -n js,srv "npm run watch-js" nodemon
      srv:rs
 
  - Shortened NPM run commands
 
-     $ conc npm:watch-node npm:watch-js npm:watch-css
+     $ concurrently npm:watch-node npm:watch-js npm:watch-css
 
  - Shortened NPM run command with wildcard (make sure to wrap it in quotes!)
 
-     $ conc "npm:watch-*"
+     $ concurrently "npm:watch-*"
 
  - Exclude patterns so that between "lint:js" and "lint:fix:js", only "lint:js"
  is ran
 
-     $ conc "npm:*(!fix)"
+     $ concurrently "npm:*(!fix)"
 
  - Passthrough some additional arguments via '{<number>}' placeholder
 
-     $ conc -P "echo {1}" -- foo
+     $ concurrently -P "echo {1}" -- foo
 
  - Passthrough all additional arguments via '{@}' placeholder
 
-     $ conc -P "npm:dev-* -- {@}" -- --watch --noEmit
+     $ concurrently -P "npm:dev-* -- {@}" -- --watch --noEmit
 
  - Passthrough all additional arguments combined via '{*}' placeholder
 
-     $ conc -P "npm:dev-* -- {*}" -- --watch --noEmit
+     $ concurrently -P "npm:dev-* -- {*}" -- --watch --noEmit
 
 For more details, visit https://github.com/open-cli-tools/concurrently
 ```

--- a/README.md
+++ b/README.md
@@ -57,10 +57,12 @@ npm install concurrently --save
 
 ## Usage
 
+`concurrently` has an alias `conc`. I use conc throughout the following, but you can always replace `conc` with `concurrently`
+
 Remember to surround separate commands with quotes:
 
 ```bash
-concurrently "command1 arg" "command2 arg"
+conc "command1 arg" "command2 arg"
 ```
 
 Otherwise **concurrently** would try to run 4 separate commands:
@@ -69,16 +71,16 @@ Otherwise **concurrently** would try to run 4 separate commands:
 In package.json, escape quotes:
 
 ```bash
-"start": "concurrently \"command1 arg\" \"command2 arg\""
+"start": "conc \"command1 arg\" \"command2 arg\""
 ```
 
 NPM run commands can be shortened:
 
 ```bash
-concurrently "npm:watch-js" "npm:watch-css" "npm:watch-node"
+conc "npm:watch-js" "npm:watch-css" "npm:watch-node"
 
 # Equivalent to:
-concurrently -n watch-js,watch-css,watch-node "npm run watch-js" "npm run watch-css" "npm run watch-node"
+conc -n watch-js,watch-css,watch-node "npm run watch-js" "npm run watch-css" "npm run watch-node"
 ```
 
 NPM shortened commands also support wildcards. Given the following scripts in
@@ -99,17 +101,17 @@ package.json:
 ```
 
 ```bash
-concurrently "npm:watch-*"
+conc "npm:watch-*"
 
 # Equivalent to:
-concurrently -n js,css,node "npm run watch-js" "npm run watch-css" "npm run watch-node"
+conc -n js,css,node "npm run watch-js" "npm run watch-css" "npm run watch-node"
 
 # Any name provided for the wildcard command will be used as a prefix to the wildcard
 # part of the script name:
-concurrently -n w: npm:watch-*
+conc -n w: npm:watch-*
 
 # Equivalent to:
-concurrently -n w:js,w:css,w:node "npm run watch-js" "npm run watch-css" "npm run watch-node"
+conc -n w:js,w:css,w:node "npm run watch-js" "npm run watch-css" "npm run watch-node"
 ```
 
 Exclusion is also supported. Given the following scripts in package.json:
@@ -131,7 +133,7 @@ Exclusion is also supported. Given the following scripts in package.json:
 ```bash
 # Running only lint:js and lint:ts
 #   with lint:fix:js and lint:fix:ts excluded
-concurrently "npm:lint:*(!fix)"
+conc "npm:lint:*(!fix)"
 ```
 
 Good frontend one-liner example [here](https://github.com/kimmobrunfeldt/dont-copy-paste-this-frontend-template/blob/5cd2bde719654941bdfc0a42c6f1b8e69ae79980/package.json#L9).
@@ -139,7 +141,7 @@ Good frontend one-liner example [here](https://github.com/kimmobrunfeldt/dont-co
 Help:
 
 ```
-concurrently [options] <command ...>
+conc [options] <command ...>
 
 General
   -m, --max-processes          How many processes should run at once.
@@ -149,7 +151,7 @@ General
                                template.
                                Example names: "main,browser,server"     [string]
       --name-separator         The character to split <names> on. Example usage:
-                               concurrently -n "styles|scripts|server"
+                               conc -n "styles|scripts|server"
                                --name-separator "|"               [default: ","]
   -s, --success                Which command(s) must exit with code 0 in order
                                for concurrently exit with code 0 too. Options
@@ -232,65 +234,65 @@ Examples:
 
  - Output nothing more than stdout+stderr of child processes
 
-     $ concurrently --raw "npm run watch-less" "npm run watch-js"
+     $ conc --raw "npm run watch-less" "npm run watch-js"
 
  - Normal output but without colors e.g. when logging to file
 
-     $ concurrently --no-color "grunt watch" "http-server" > log
+     $ conc --no-color "grunt watch" "http-server" > log
 
  - Custom prefix
 
-     $ concurrently --prefix "{time}-{pid}" "npm run watch" "http-server"
+     $ conc --prefix "{time}-{pid}" "npm run watch" "http-server"
 
  - Custom names and colored prefixes
 
-     $ concurrently --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold"
+     $ conc --names "HTTP,WATCH" -c "bgBlue.bold,bgMagenta.bold"
      "http-server" "npm run watch"
 
  - Configuring via environment variables with CONCURRENTLY_ prefix
 
-     $ CONCURRENTLY_RAW=true CONCURRENTLY_KILL_OTHERS=true concurrently "echo
+     $ CONCURRENTLY_RAW=true CONCURRENTLY_KILL_OTHERS=true conc "echo
      hello" "echo world"
 
  - Send input to default
 
-     $ concurrently --handle-input "nodemon" "npm run watch-js"
+     $ conc --handle-input "nodemon" "npm run watch-js"
      rs  # Sends rs command to nodemon process
 
  - Send input to specific child identified by index
 
-     $ concurrently --handle-input "npm run watch-js" nodemon
+     $ conc --handle-input "npm run watch-js" nodemon
      1:rs
 
  - Send input to specific child identified by name
 
-     $ concurrently --handle-input -n js,srv "npm run watch-js" nodemon
+     $ conc --handle-input -n js,srv "npm run watch-js" nodemon
      srv:rs
 
  - Shortened NPM run commands
 
-     $ concurrently npm:watch-node npm:watch-js npm:watch-css
+     $ conc npm:watch-node npm:watch-js npm:watch-css
 
  - Shortened NPM run command with wildcard (make sure to wrap it in quotes!)
 
-     $ concurrently "npm:watch-*"
+     $ conc "npm:watch-*"
 
  - Exclude patterns so that between "lint:js" and "lint:fix:js", only "lint:js"
  is ran
 
-     $ concurrently "npm:*(!fix)"
+     $ conc "npm:*(!fix)"
 
  - Passthrough some additional arguments via '{<number>}' placeholder
 
-     $ concurrently -P "echo {1}" -- foo
+     $ conc -P "echo {1}" -- foo
 
  - Passthrough all additional arguments via '{@}' placeholder
 
-     $ concurrently -P "npm:dev-* -- {@}" -- --watch --noEmit
+     $ conc -P "npm:dev-* -- {@}" -- --watch --noEmit
 
  - Passthrough all additional arguments combined via '{*}' placeholder
 
-     $ concurrently -P "npm:dev-* -- {*}" -- --watch --noEmit
+     $ conc -P "npm:dev-* -- {*}" -- --watch --noEmit
 
 For more details, visit https://github.com/open-cli-tools/concurrently
 ```

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -43,7 +43,7 @@ const args = yargs(argsBeforeSep)
         'name-separator': {
             describe:
                 'The character to split <names> on. Example usage:\n' +
-                'concurrently -n "styles|scripts|server" --name-separator "|"',
+                'conc -n "styles|scripts|server" --name-separator "|"',
             default: defaults.nameSeparator,
         },
         success: {

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -43,7 +43,7 @@ const args = yargs(argsBeforeSep)
         'name-separator': {
             describe:
                 'The character to split <names> on. Example usage:\n' +
-                'conc -n "styles|scripts|server" --name-separator "|"',
+                '-n "styles|scripts|server" --name-separator "|"',
             default: defaults.nameSeparator,
         },
         success: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "yargs": "^17.3.1"
       },
       "bin": {
+        "conc": "dist/bin/concurrently.js",
         "concurrently": "dist/bin/concurrently.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "dist/src/index.d.ts",
   "type": "commonjs",
   "bin": {
-    "concurrently": "./dist/bin/concurrently.js"
+    "concurrently": "./dist/bin/concurrently.js",
+    "conc": "./dist/bin/concurrently.js"
   },
   "engines": {
     "node": "^12.20.0 || ^14.13.0 || >=16.0.0"


### PR DESCRIPTION
`concurrently` is too long, which makes it unfriendly to non-English users and tiresome to type, which discourages potential users.

It simplifies the multiple-entry command `&&`, but not in the command line name. Let's add a shorthand to simplify it. Use `conc` shorthand