### PR TITLE
Increase timeout for build step of concurrently in tests

### DIFF
--- a/bin/concurrently.spec.ts
+++ b/bin/concurrently.spec.ts
@@ -25,10 +25,10 @@ beforeAll(async () => {
         bundle: true,
         outfile: path.join(tmpDir, 'concurrently.js'),
     });
-});
+}, 8000);
 
 afterAll(() => {
-    // Remove the temporary directory
+    // Remove the temporary directory where 'concurrently' was stored
     if (tmpDir) {
         fs.rmdirSync(tmpDir, { recursive: true });
     }


### PR DESCRIPTION
Sometimes the default Jest timeout of 5000ms is reached on GitHub CI.