### PR TITLE
Fix onFinish signature when using exactOptionalPropertyTypes

### DIFF
--- a/src/flow-control/input-handler.ts
+++ b/src/flow-control/input-handler.ts
@@ -39,7 +39,10 @@ export class InputHandler implements FlowController {
         this.pauseInputStreamOnFinish = pauseInputStreamOnFinish !== false;
     }
 
-    handle(commands: Command[]) {
+    handle(commands: Command[]): {
+        commands: Command[];
+        onFinish?: () => void | undefined;
+    } {
         if (!this.inputStream) {
             return { commands };
         }


### PR DESCRIPTION
Seeing this error:

![image](https://user-images.githubusercontent.com/30204280/195337646-a6d7e811-ff7c-4dc6-b722-423c8d0da08c.png)

When consuming `concurrently` in a project with `exactOptionalPropertyTypes` enabled.