### PR TITLE
Revert "Replace deprecated killable prop with new canKill method"

### DIFF
--- a/src/fixtures/fake-command.ts
+++ b/src/fixtures/fake-command.ts
@@ -5,8 +5,11 @@ import { PassThrough, Writable } from 'stream';
 import { ChildProcess, CloseEvent, Command, CommandInfo } from '../command';
 
 export class FakeCommand extends Command {
-    // Placeholder value for dynamically mocking `canKill` in 'kill-others.spec.ts'.
+    // Type-safe workaround for setting `killable` to a custom value.
     isKillable = false;
+    get killable() {
+        return this.isKillable;
+    }
 
     constructor(name = 'foo', command = 'echo foo', index = 0, info?: Partial<CommandInfo>) {
         super(

--- a/src/flow-control/kill-others.spec.ts
+++ b/src/flow-control/kill-others.spec.ts
@@ -1,16 +1,8 @@
 import { createMockInstance } from 'jest-create-mock-instance';
 
-import { Command } from '../command';
 import { createFakeCloseEvent, FakeCommand } from '../fixtures/fake-command';
 import { Logger } from '../logger';
 import { KillOthers, ProcessCloseCondition } from './kill-others';
-
-// Return a custom value for `canKill` (also see 'FakeCommand').
-beforeAll(() => {
-    jest.spyOn(Command, 'canKill').mockImplementation(
-        (command) => (command as FakeCommand).isKillable
-    );
-});
 
 let commands: FakeCommand[];
 let logger: Logger;

--- a/src/flow-control/kill-others.ts
+++ b/src/flow-control/kill-others.ts
@@ -45,7 +45,7 @@ export class KillOthers implements FlowController {
 
         closeStates.forEach((closeState) =>
             closeState.subscribe(() => {
-                const killableCommands = commands.filter((command) => Command.canKill(command));
+                const killableCommands = commands.filter((command) => command.killable);
                 if (killableCommands.length) {
                     this.logger.logGlobalEvent('Sending SIGTERM to other processes..');
                     killableCommands.forEach((command) => command.kill());


### PR DESCRIPTION
Reverts open-cli-tools/concurrently#378

~I'm not sure if it's related but tests seems to be flappy since this change.~ No, not related...