### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  gh-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes
+
+  publish-npm:
+    name: Publish to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org
+
+      - name: Setup NPM cache
+        uses: ./.github/actions/setup-npm-cache
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,6 @@ jobs:
         run: npm ci
 
       - name: Publish to NPM
-        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,8 @@ Please fix them and then run the commit command again.
 
 ## Test
 
-Tests can be run with the command:
+Tests can be executed with the following command:
 
 ```bash
 npm test
 ```
-
-## Release
-
-Use [np](https://www.npmjs.com/package/np) to create a new release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "jest-create-mock-instance": "^2.0.0",
         "lint-staged": "^12.4.1",
         "prettier": "^2.6.2",
+        "safe-publish-latest": "^2.0.0",
         "simple-git-hooks": "^2.7.0",
         "string-argv": "^0.3.1",
         "typescript": "~4.9.3"
@@ -4110,6 +4111,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/in-publish": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
+      "dev": true,
+      "bin": {
+        "in-install": "in-install.js",
+        "in-publish": "in-publish.js",
+        "not-in-install": "not-in-install.js",
+        "not-in-publish": "not-in-publish.js"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -6426,6 +6439,26 @@
       "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-publish-latest": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-publish-latest/-/safe-publish-latest-2.0.0.tgz",
+      "integrity": "sha512-Qc6L9iNKfNl24X8O4XS31yHo49jX1IH+DsnxHIbCDjoARckTOk0Cj9v8G2IYVvZjj94dc9tjs2WIUtL8epJqvw==",
+      "dev": true,
+      "dependencies": {
+        "in-publish": "^2.0.1",
+        "semver": "^7.3.5",
+        "yargs": "^17.2.1"
+      },
+      "bin": {
+        "safe-publish-latest": "bin/safe-publish-latest"
+      },
+      "engines": {
+        "node": ">= 12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/safe-regex-test": {
@@ -10121,6 +10154,12 @@
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
+    "in-publish": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
+      "dev": true
+    },
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -11856,6 +11895,17 @@
       "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
       "requires": {
         "tslib": "^2.1.0"
+      }
+    },
+    "safe-publish-latest": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/safe-publish-latest/-/safe-publish-latest-2.0.0.tgz",
+      "integrity": "sha512-Qc6L9iNKfNl24X8O4XS31yHo49jX1IH+DsnxHIbCDjoARckTOk0Cj9v8G2IYVvZjj94dc9tjs2WIUtL8epJqvw==",
+      "dev": true,
+      "requires": {
+        "in-publish": "^2.0.1",
+        "semver": "^7.3.5",
+        "yargs": "^17.2.1"
       }
     },
     "safe-regex-test": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "format:fix": "npm run format -- --write",
     "lint": "eslint . --ext mjs,js,ts --ignore-path .gitignore",
     "lint:fix": "npm run lint -- --fix",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "safe-publish-latest && npm run build",
     "report-coverage": "cat coverage/lcov.info | coveralls",
     "test": "jest"
   },
@@ -84,6 +84,7 @@
     "jest-create-mock-instance": "^2.0.0",
     "lint-staged": "^12.4.1",
     "prettier": "^2.6.2",
+    "safe-publish-latest": "^2.0.0",
     "simple-git-hooks": "^2.7.0",
     "string-argv": "^0.3.1",
     "typescript": "~4.9.3"


### PR DESCRIPTION
Adding a simple GitHub workflow which does create a GitHub release (with auto-generated changelog) and publish the NPM package on push of version tags.

With this workflow the process would then look as follows:
1. Run `npm version ...` locally
2. Push to GitHub, e.g. `git push && git push --tags`
3. Let the workflow do the rest (and maybe check / adjust the release notes) 

I've added [safe-publish-latest](https://github.com/ljharb/safe-publish-latest) as a safety measure, which makes sure the publish process will only run if the version is a valid "latest" version.

@gustavohenke This would allow me to create releases as well. Feel free to close this pull request in case you prefer to retain the sole person to do so. Otherwise, can you please create a "NPM Automation Access Token" and store it under a secret called `NPM_TOKEN` in this repo. Thanks!