### PR TITLE
Support REPL languages that use colons

### DIFF
--- a/src/flow-control/input-handler.spec.ts
+++ b/src/flow-control/input-handler.spec.ts
@@ -55,11 +55,13 @@ it('forwards input stream to target index specified in input', () => {
 
     inputStream.write('1:something');
     inputStream.write(' 1:ignore_leading_whitespace');
+    inputStream.write('1:multi\nline\n');
 
     expect(commands[0].stdin?.write).not.toHaveBeenCalled();
-    expect(commands[1].stdin?.write).toHaveBeenCalledTimes(2);
+    expect(commands[1].stdin?.write).toHaveBeenCalledTimes(3);
     expect(commands[1].stdin?.write).toHaveBeenCalledWith('something');
     expect(commands[1].stdin?.write).toHaveBeenCalledWith('ignore_leading_whitespace');
+    expect(commands[1].stdin?.write).toHaveBeenCalledWith('multi\nline\n');
 });
 
 it('forwards input stream to target index specified in input when input contains colon', () => {
@@ -79,15 +81,19 @@ it('does not forward input stream when input contains colon in a different forma
 
     inputStream.emit('data', Buffer.from('Ruby0::Const::Syntax'));
     inputStream.emit('data', Buffer.from('1:Ruby1::Const::Syntax'));
-    inputStream.emit('data', Buffer.from('ruby_keyword_arg(foo: :bar)'));
-    inputStream.emit('data', Buffer.from('ruby_hash = { foo: :bar }'));
+    inputStream.emit('data', Buffer.from('ruby_symbol_arg :my_symbol'));
+    inputStream.emit('data', Buffer.from('ruby_symbol_arg(:my_symbol)'));
+    inputStream.emit('data', Buffer.from('{foo: :bar}'));
+    inputStream.emit('data', Buffer.from('{:foo=>:bar}'));
 
     expect(commands[1].stdin?.write).toHaveBeenCalledTimes(1);
     expect(commands[1].stdin?.write).toHaveBeenCalledWith('Ruby1::Const::Syntax');
-    expect(commands[0].stdin?.write).toHaveBeenCalledTimes(3);
+    expect(commands[0].stdin?.write).toHaveBeenCalledTimes(5);
     expect(commands[0].stdin?.write).toHaveBeenCalledWith('Ruby0::Const::Syntax');
-    expect(commands[0].stdin?.write).toHaveBeenCalledWith('ruby_keyword_arg(foo: :bar)');
-    expect(commands[0].stdin?.write).toHaveBeenCalledWith('ruby_hash = { foo: :bar }');
+    expect(commands[0].stdin?.write).toHaveBeenCalledWith('ruby_symbol_arg :my_symbol');
+    expect(commands[0].stdin?.write).toHaveBeenCalledWith('ruby_symbol_arg(:my_symbol)');
+    expect(commands[0].stdin?.write).toHaveBeenCalledWith('{foo: :bar}');
+    expect(commands[0].stdin?.write).toHaveBeenCalledWith('{:foo=>:bar}');
 });
 
 it('forwards input stream to target name specified in input', () => {

--- a/src/flow-control/input-handler.spec.ts
+++ b/src/flow-control/input-handler.spec.ts
@@ -54,13 +54,11 @@ it('forwards input stream to target index specified in input', () => {
     controller.handle(commands);
 
     inputStream.write('1:something');
-    inputStream.write(' 1:ignore_leading_whitespace');
     inputStream.write('1:multi\nline\n');
 
     expect(commands[0].stdin?.write).not.toHaveBeenCalled();
-    expect(commands[1].stdin?.write).toHaveBeenCalledTimes(3);
+    expect(commands[1].stdin?.write).toHaveBeenCalledTimes(2);
     expect(commands[1].stdin?.write).toHaveBeenCalledWith('something');
-    expect(commands[1].stdin?.write).toHaveBeenCalledWith('ignore_leading_whitespace');
     expect(commands[1].stdin?.write).toHaveBeenCalledWith('multi\nline\n');
 });
 

--- a/src/flow-control/input-handler.spec.ts
+++ b/src/flow-control/input-handler.spec.ts
@@ -54,22 +54,40 @@ it('forwards input stream to target index specified in input', () => {
     controller.handle(commands);
 
     inputStream.write('1:something');
+    inputStream.write(' 1:ignore_leading_whitespace');
 
     expect(commands[0].stdin?.write).not.toHaveBeenCalled();
-    expect(commands[1].stdin?.write).toHaveBeenCalledTimes(1);
+    expect(commands[1].stdin?.write).toHaveBeenCalledTimes(2);
     expect(commands[1].stdin?.write).toHaveBeenCalledWith('something');
+    expect(commands[1].stdin?.write).toHaveBeenCalledWith('ignore_leading_whitespace');
 });
 
 it('forwards input stream to target index specified in input when input contains colon', () => {
     controller.handle(commands);
 
-    inputStream.emit('data', Buffer.from('1::something'));
+    inputStream.emit('data', Buffer.from('1: :something'));
     inputStream.emit('data', Buffer.from('1:some:thing'));
 
     expect(commands[0].stdin?.write).not.toHaveBeenCalled();
     expect(commands[1].stdin?.write).toHaveBeenCalledTimes(2);
-    expect(commands[1].stdin?.write).toHaveBeenCalledWith(':something');
+    expect(commands[1].stdin?.write).toHaveBeenCalledWith(' :something');
     expect(commands[1].stdin?.write).toHaveBeenCalledWith('some:thing');
+});
+
+it('does not forward input stream when input contains colon in a different format', () => {
+    controller.handle(commands);
+
+    inputStream.emit('data', Buffer.from('Ruby0::Const::Syntax'));
+    inputStream.emit('data', Buffer.from('1:Ruby1::Const::Syntax'));
+    inputStream.emit('data', Buffer.from('ruby_keyword_arg(foo: :bar)'));
+    inputStream.emit('data', Buffer.from('ruby_hash = { foo: :bar }'));
+
+    expect(commands[1].stdin?.write).toHaveBeenCalledTimes(1);
+    expect(commands[1].stdin?.write).toHaveBeenCalledWith('Ruby1::Const::Syntax');
+    expect(commands[0].stdin?.write).toHaveBeenCalledTimes(3);
+    expect(commands[0].stdin?.write).toHaveBeenCalledWith('Ruby0::Const::Syntax');
+    expect(commands[0].stdin?.write).toHaveBeenCalledWith('ruby_keyword_arg(foo: :bar)');
+    expect(commands[0].stdin?.write).toHaveBeenCalledWith('ruby_hash = { foo: :bar }');
 });
 
 it('forwards input stream to target name specified in input', () => {

--- a/src/flow-control/input-handler.ts
+++ b/src/flow-control/input-handler.ts
@@ -57,11 +57,11 @@ export class InputHandler implements FlowController {
         Rx.fromEvent(inputStream, 'data')
             .pipe(map((data) => String(data)))
             .subscribe((data) => {
-                const dataMatch = data.match(/^\s*([\w-]+):(?!:)(.+)$/);
-                const targetId = dataMatch ? dataMatch[1] : this.defaultInputTarget;
+                const dataMatch = data.match(/^\s*([\w-]+):(?!:)(.+)$/s);
+                const targetId = dataMatch ? dataMatch[1] : this.defaultInputTarget.toString();
                 const input = dataMatch ? dataMatch[2] : data;
 
-                const command = commandsMap.get(targetId.toString());
+                const command = commandsMap.get(targetId);
 
                 if (command && command.stdin) {
                     command.stdin.write(input);


### PR DESCRIPTION
It's common for a server command to have a built-in REPL for debugging, e.g. a Node.js server with `debugger` or a Rails server with `binding.pry`. This PR adds support for writing most syntaxes into the concurrently input stream. Specifically, we need to allow colons that commonly appear in code, without it changing the target input stream.

e.g. the following Javascript should be a valid input:
```js
myFunc({ foo: "bar" })
```
Before this PR, this would fail with the error: `Unable to find command "myFunc({ foo", or it has no stdin open`

**Breaking changes:**
- drop support for `1::something` (so we can support `Ruby::Const::Syntax`). we'll still support `1: :something` and `1:Ruby::Const::Syntax`

---

Speaking of REPL, it'd be great to support REPL keystrokes like backspaces, arrow left, etc. but I'm not sure how to do that... 