### PR TITLE
Send SIGKILL to other processes

### DIFF
--- a/bin/concurrently.spec.ts
+++ b/bin/concurrently.spec.ts
@@ -12,7 +12,7 @@ import { map } from 'rxjs/operators';
 import stringArgv from 'string-argv';
 
 const isWindows = process.platform === 'win32';
-const createKillMessage = (prefix: string, signal: 'SIGTERM' | 'SIGINT' | string) => {
+const createKillMessage = (prefix: string, signal: 'SIGKILL' | 'SIGTERM' | 'SIGINT' | string) => {
     const map: Record<string, string | number> = {
         SIGTERM: isWindows ? 1 : '(SIGTERM|143)',
         // Could theoretically be anything (e.g. 0) if process has SIGINT handler
@@ -301,11 +301,11 @@ describe('--kill-others', () => {
 
             expect(lines).toContainEqual(expect.stringContaining('[1] exit 0 exited with code 0'));
             expect(lines).toContainEqual(
-                expect.stringContaining('Sending SIGTERM to other processes')
+                expect.stringContaining('Sending SIGKILL to other processes')
             );
             expect(lines).toContainEqual(
                 expect.stringMatching(
-                    createKillMessage('[0] node fixtures/sleep.mjs 10', 'SIGTERM')
+                    createKillMessage('[0] node fixtures/sleep.mjs 10', 'SIGKILL')
                 )
             );
         });
@@ -317,9 +317,9 @@ describe('--kill-others', () => {
         ).getLogLines();
 
         expect(lines).toContainEqual(expect.stringContaining('[1] exit 1 exited with code 1'));
-        expect(lines).toContainEqual(expect.stringContaining('Sending SIGTERM to other processes'));
+        expect(lines).toContainEqual(expect.stringContaining('Sending SIGKILL to other processes'));
         expect(lines).toContainEqual(
-            expect.stringMatching(createKillMessage('[0] node fixtures/sleep.mjs 10', 'SIGTERM'))
+            expect.stringMatching(createKillMessage('[0] node fixtures/sleep.mjs 10', 'SIGKILL'))
         );
     });
 });
@@ -342,9 +342,9 @@ describe('--kill-others-on-fail', () => {
         ).getLogLines();
 
         expect(lines).toContainEqual(expect.stringContaining('[1] exit 1 exited with code 1'));
-        expect(lines).toContainEqual(expect.stringContaining('Sending SIGTERM to other processes'));
+        expect(lines).toContainEqual(expect.stringContaining('Sending SIGKILL to other processes'));
         expect(lines).toContainEqual(
-            expect.stringMatching(createKillMessage('[0] node fixtures/sleep.mjs 10', 'SIGTERM'))
+            expect.stringMatching(createKillMessage('[0] node fixtures/sleep.mjs 10', 'SIGKILL'))
         );
     });
 });
@@ -384,7 +384,7 @@ describe('--handle-input', () => {
         expect(exit.code).toBeGreaterThan(0);
         expect(lines).toContainEqual(expect.stringContaining('[1] stop'));
         expect(lines).toContainEqual(
-            expect.stringMatching(createKillMessage('[0] node fixtures/read-echo.js', 'SIGTERM'))
+            expect.stringMatching(createKillMessage('[0] node fixtures/read-echo.js', 'SIGKILL'))
         );
     });
 
@@ -401,7 +401,7 @@ describe('--handle-input', () => {
         expect(exit.code).toBeGreaterThan(0);
         expect(lines).toContainEqual(expect.stringContaining('[1] stop'));
         expect(lines).toContainEqual(
-            expect.stringMatching(createKillMessage('[0] node fixtures/read-echo.js', 'SIGTERM'))
+            expect.stringMatching(createKillMessage('[0] node fixtures/read-echo.js', 'SIGKILL'))
         );
     });
 });

--- a/bin/concurrently.spec.ts
+++ b/bin/concurrently.spec.ts
@@ -14,6 +14,7 @@ import stringArgv from 'string-argv';
 const isWindows = process.platform === 'win32';
 const createKillMessage = (prefix: string, signal: 'SIGKILL' | 'SIGTERM' | 'SIGINT' | string) => {
     const map: Record<string, string | number> = {
+        SIGKILL: isWindows ? 1 : '(SIGKILL|137)',
         SIGTERM: isWindows ? 1 : '(SIGTERM|143)',
         // Could theoretically be anything (e.g. 0) if process has SIGINT handler
         SIGINT: isWindows ? '(3221225786|0)' : '(SIGINT|130|0)',

--- a/src/flow-control/kill-others.spec.ts
+++ b/src/flow-control/kill-others.spec.ts
@@ -46,7 +46,7 @@ it('kills other killable processes on success', () => {
     commands[0].close.next(createFakeCloseEvent({ exitCode: 0 }));
 
     expect(logger.logGlobalEvent).toHaveBeenCalledTimes(1);
-    expect(logger.logGlobalEvent).toHaveBeenCalledWith('Sending SIGTERM to other processes..');
+    expect(logger.logGlobalEvent).toHaveBeenCalledWith('Sending SIGKILL to other processes..');
     expect(commands[0].kill).not.toHaveBeenCalled();
     expect(commands[1].kill).toHaveBeenCalled();
 });
@@ -67,7 +67,7 @@ it('kills other killable processes on failure', () => {
     commands[0].close.next(createFakeCloseEvent({ exitCode: 1 }));
 
     expect(logger.logGlobalEvent).toHaveBeenCalledTimes(1);
-    expect(logger.logGlobalEvent).toHaveBeenCalledWith('Sending SIGTERM to other processes..');
+    expect(logger.logGlobalEvent).toHaveBeenCalledWith('Sending SIGKILL to other processes..');
     expect(commands[0].kill).not.toHaveBeenCalled();
     expect(commands[1].kill).toHaveBeenCalled();
 });

--- a/src/flow-control/kill-others.ts
+++ b/src/flow-control/kill-others.ts
@@ -47,8 +47,8 @@ export class KillOthers implements FlowController {
             closeState.subscribe(() => {
                 const killableCommands = commands.filter((command) => Command.canKill(command));
                 if (killableCommands.length) {
-                    this.logger.logGlobalEvent('Sending SIGTERM to other processes..');
-                    killableCommands.forEach((command) => command.kill());
+                    this.logger.logGlobalEvent('Sending SIGKILL to other processes..');
+                    killableCommands.forEach((command) => command.kill('SIGKILL'));
                 }
             })
         );


### PR DESCRIPTION
When the main process exits, force the other processes to exit with the SIGKILL signal. (Instead of SIGTERM.)

Fixes https://github.com/open-cli-tools/concurrently/issues/395