### PR TITLE
add --kill-signal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,8 @@ Killing other processes
   -k, --kill-others          Kill other processes if one exits or dies.[boolean]
       --kill-others-on-fail  Kill other processes if one exits with non zero
                              status code.                              [boolean]
-      --kill-signal          Signal to send to other processes if one exits or dies. [string]
+      --kill-signal          Signal to send to other processes if one exits or dies.
+                             (SIGTERM/SIGKILL, defaults to SIGTERM)    [string]
 
 Restarting
       --restart-tries  How many times a process that died should restart.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Killing other processes
   -k, --kill-others          Kill other processes if one exits or dies.[boolean]
       --kill-others-on-fail  Kill other processes if one exits with non zero
                              status code.                              [boolean]
+      --kill-signal          Signal to send to other processes if one exits or dies. [string]
 
 Restarting
       --restart-tries  How many times a process that died should restart.

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -110,6 +110,11 @@ const args = yargs(argsBeforeSep)
             describe: 'Kill other processes if one exits with non zero status code.',
             type: 'boolean',
         },
+        'kill-signal': {
+            alias: 'ks',
+            describe: 'Signal to send to other processes if one exits or dies.',
+            type: 'string',
+        },
 
         // Prefix
         prefix: {
@@ -208,6 +213,7 @@ concurrently(
             : args.killOthersOnFail
             ? ['failure']
             : [],
+        killSignal: args.killSignal,
         maxProcesses: args.maxProcesses,
         raw: args.raw,
         hide: args.hide.split(','),

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -112,8 +112,10 @@ const args = yargs(argsBeforeSep)
         },
         'kill-signal': {
             alias: 'ks',
-            describe: 'Signal to send to other processes if one exits or dies.',
+            describe:
+                'Signal to send to other processes if one exits or dies. (SIGTERM/SIGKILL, defaults to SIGTERM)',
             type: 'string',
+            default: defaults.killSignal,
         },
 
         // Prefix

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -190,7 +190,7 @@ const args = yargs(argsBeforeSep)
     )
     .group(['p', 'c', 'l', 't'], 'Prefix styling')
     .group(['i', 'default-input-target'], 'Input handling')
-    .group(['k', 'kill-others-on-fail'], 'Killing other processes')
+    .group(['k', 'kill-others-on-fail', 'kill-signal'], 'Killing other processes')
     .group(['restart-tries', 'restart-after'], 'Restarting')
     .epilogue(epilogue)
     .parseSync();

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -111,6 +111,11 @@ export type ConcurrentlyOptions = {
     kill: KillProcess;
 
     /**
+     * Signal to send to killed processes.
+     */
+    killSignal?: string;
+
+    /**
      * List of additional arguments passed that will get replaced in each command.
      * If not defined, no argument replacing will happen.
      *

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -80,3 +80,10 @@ export const timings = false;
  * Passthrough additional arguments to commands (accessible via placeholders) instead of treating them as commands.
  */
 export const passthroughArguments = false;
+
+/**
+ * Signal to send to other processes if one exits or dies.
+ *
+ * Defaults to OS specific signal. (SIGTERM on Linux/MacOS)
+ */
+export const killSignal: string | undefined = undefined;

--- a/src/flow-control/kill-others.spec.ts
+++ b/src/flow-control/kill-others.spec.ts
@@ -23,6 +23,7 @@ const createWithConditions = (conditions: ProcessCloseCondition[]) =>
     new KillOthers({
         logger,
         conditions,
+        killSignal: undefined,
     });
 
 it('returns same commands', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ export default (
             new KillOthers({
                 logger,
                 conditions: options.killOthers || [],
+                killSignal: options.killSignal,
             }),
             new LogTimings({
                 logger: options.timings ? logger : undefined,


### PR DESCRIPTION
Add a --kill-signal option to change what signal is sent to the other processes.

Fixes #395 