### PR TITLE
Add support for Bun

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ tired of opening terminals and made **concurrently**.
 
 **concurrently** can be installed in the global scope (if you'd like to have it available and use it on the whole system) or locally for a specific package (for example if you'd like to use it in the `scripts` section of your package):
 
-|             | npm                     | Yarn                           | pnpm                       |
-| ----------- | ----------------------- | ------------------------------ | -------------------------- |
-| **Global**  | `npm i -g concurrently` | `yarn global add concurrently` | `pnpm add -g concurrently` |
-| **Local**\* | `npm i -D concurrently` | `yarn add -D concurrently`     | `pnpm add -D concurrently` |
+|             | npm                     | Yarn                           | pnpm                       | Bun                       |
+| ----------- | ----------------------- | ------------------------------ | -------------------------- | ------------------------- |
+| **Global**  | `npm i -g concurrently` | `yarn global add concurrently` | `pnpm add -g concurrently` | `bun add -g concurrently` |
+| **Local**\* | `npm i -D concurrently` | `yarn add -D concurrently`     | `pnpm add -D concurrently` | `bun add -d concurrently` |
 
 <sub>\* It's recommended to add **concurrently** to `devDependencies` as it's usually used for developing purposes. Please adjust the command if this doesn't apply in your case.</sub>
 
@@ -427,6 +427,6 @@ It contains the following properties:
   So _null_ means the process didn't terminate normally. This will make **concurrently**
   to return non-zero exit code too.
 
-- Does this work with the npm-replacements [yarn](https://github.com/yarnpkg/yarn) or [pnpm](https://pnpm.js.org/)?
+- Does this work with the npm-replacements [yarn](https://github.com/yarnpkg/yarn), [pnpm](https://pnpm.js.org/), or [Bun](https://bun.sh/)?
 
-  Yes! In all examples above, you may replace "`npm`" with "`yarn`" or "`pnpm`".
+  Yes! In all examples above, you may replace "`npm`" with "`yarn`", "`pnpm`", or "`bun`".

--- a/src/command-parser/expand-npm-shortcut.spec.ts
+++ b/src/command-parser/expand-npm-shortcut.spec.ts
@@ -13,7 +13,7 @@ it('returns same command if no npm: prefix is present', () => {
     expect(parser.parse(commandInfo)).toBe(commandInfo);
 });
 
-for (const npmCmd of ['npm', 'yarn', 'pnpm']) {
+for (const npmCmd of ['npm', 'yarn', 'pnpm', 'bun']) {
     describe(`with ${npmCmd}: prefix`, () => {
         it(`expands to "${npmCmd} run <script> <args>"`, () => {
             const commandInfo = createCommandInfo(`${npmCmd}:foo -- bar`, 'echo');

--- a/src/command-parser/expand-npm-shortcut.ts
+++ b/src/command-parser/expand-npm-shortcut.ts
@@ -2,12 +2,12 @@ import { CommandInfo } from '../command';
 import { CommandParser } from './command-parser';
 
 /**
- * Expands commands prefixed with `npm:`, `yarn:` or `pnpm:` into the full version `npm run <command>` and so on.
+ * Expands commands prefixed with `npm:`, `yarn:`, `pnpm:`, or `bun:` into the full version `npm run <command>` and so on.
  */
 export class ExpandNpmShortcut implements CommandParser {
     parse(commandInfo: CommandInfo) {
         const [, npmCmd, cmdName, args] =
-            commandInfo.command.match(/^(npm|yarn|pnpm):(\S+)(.*)/) || [];
+            commandInfo.command.match(/^(npm|yarn|pnpm|bun):(\S+)(.*)/) || [];
         if (!cmdName) {
             return commandInfo;
         }

--- a/src/command-parser/expand-npm-wildcard.spec.ts
+++ b/src/command-parser/expand-npm-wildcard.spec.ts
@@ -67,7 +67,7 @@ it('expands to nothing if no scripts exist in package.json', () => {
     expect(parser.parse(createCommandInfo('npm run foo-*-baz qux'))).toEqual([]);
 });
 
-for (const npmCmd of ['npm', 'yarn', 'pnpm']) {
+for (const npmCmd of ['npm', 'yarn', 'pnpm', 'bun']) {
     describe(`with an ${npmCmd}: prefix`, () => {
         it('expands to all scripts matching pattern', () => {
             readPkg.mockReturnValue({

--- a/src/command-parser/expand-npm-wildcard.ts
+++ b/src/command-parser/expand-npm-wildcard.ts
@@ -7,7 +7,7 @@ import { CommandParser } from './command-parser';
 const OMISSION = /\(!([^)]+)\)/;
 
 /**
- * Finds wildcards in npm/yarn/pnpm run commands and replaces them with all matching scripts in the
+ * Finds wildcards in npm/yarn/pnpm/bun run commands and replaces them with all matching scripts in the
  * `package.json` file of the current directory.
  */
 export class ExpandNpmWildcard implements CommandParser {
@@ -26,7 +26,7 @@ export class ExpandNpmWildcard implements CommandParser {
 
     parse(commandInfo: CommandInfo) {
         const [, npmCmd, cmdName, args] =
-            commandInfo.command.match(/(npm|yarn|pnpm) run (\S+)([^&]*)/) || [];
+            commandInfo.command.match(/(npm|yarn|pnpm|bun) run (\S+)([^&]*)/) || [];
         const wildcardPosition = (cmdName || '').indexOf('*');
 
         // If the regex didn't match an npm script, or it has no wildcard,


### PR DESCRIPTION
This adds support for `bun:` shortcuts (https://bun.sh), like the current `npm:`, `yarn:`, and `pnpm:` shortcuts.