### PR TITLE
Allow setting `raw` per command when using the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ For more details, visit https://github.com/open-cli-tools/concurrently
     Prefix colors specified per-command take precedence over this list.
   - `prefixLength`: how many characters to show when prefixing with `command`. Default: `10`
   - `raw`: whether raw mode should be used, meaning strictly process output will
-    be logged, without any prefixes, coloring or extra stuff.
+    be logged, without any prefixes, coloring or extra stuff. Can be overriden per command.
   - `successCondition`: the condition to consider the run was successful.
     If `first`, only the first process to exit will make up the success of the run; if `last`, the last process that exits will determine whether the run succeeds.
     Anything else means all processes should exit successfully.

--- a/src/command.ts
+++ b/src/command.ts
@@ -102,6 +102,9 @@ export class Command implements CommandInfo {
     /** @inheritdoc */
     readonly env: Record<string, unknown>;
 
+    /** @inheritdoc */
+    readonly cwd?: string;
+
     readonly close = new Rx.Subject<CloseEvent>();
     readonly error = new Rx.Subject<unknown>();
     readonly stdout = new Rx.Subject<Buffer>();
@@ -120,7 +123,7 @@ export class Command implements CommandInfo {
     }
 
     constructor(
-        { index, name, command, prefixColor, env }: CommandInfo & { index: number },
+        { index, name, command, prefixColor, env, cwd }: CommandInfo & { index: number },
         spawnOpts: SpawnOptions,
         spawn: SpawnCommand,
         killProcess: KillProcess
@@ -130,6 +133,7 @@ export class Command implements CommandInfo {
         this.command = command;
         this.prefixColor = prefixColor;
         this.env = env || {};
+        this.cwd = cwd;
         this.killProcess = killProcess;
         this.spawn = spawn;
         this.spawnOpts = spawnOpts;

--- a/src/command.ts
+++ b/src/command.ts
@@ -32,6 +32,11 @@ export interface CommandInfo {
      * Color to use on prefix of the command.
      */
     prefixColor?: string;
+
+    /**
+     * Output command in raw format
+     */
+    raw?: boolean;
 }
 
 export interface CloseEvent {

--- a/src/command.ts
+++ b/src/command.ts
@@ -34,7 +34,7 @@ export interface CommandInfo {
     prefixColor?: string;
 
     /**
-     * Output command in raw format
+     * Output command in raw format.
      */
     raw?: boolean;
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -97,9 +97,6 @@ export class Command implements CommandInfo {
     /** @inheritdoc */
     readonly env: Record<string, unknown>;
 
-    /** @inheritdoc */
-    readonly cwd?: string;
-
     readonly close = new Rx.Subject<CloseEvent>();
     readonly error = new Rx.Subject<unknown>();
     readonly stdout = new Rx.Subject<Buffer>();
@@ -118,7 +115,7 @@ export class Command implements CommandInfo {
     }
 
     constructor(
-        { index, name, command, prefixColor, env, cwd }: CommandInfo & { index: number },
+        { index, name, command, prefixColor, env }: CommandInfo & { index: number },
         spawnOpts: SpawnOptions,
         spawn: SpawnCommand,
         killProcess: KillProcess
@@ -128,7 +125,6 @@ export class Command implements CommandInfo {
         this.command = command;
         this.prefixColor = prefixColor;
         this.env = env || {};
-        this.cwd = cwd;
         this.killProcess = killProcess;
         this.spawn = spawn;
         this.spawnOpts = spawnOpts;

--- a/src/concurrently.spec.ts
+++ b/src/concurrently.spec.ts
@@ -253,6 +253,62 @@ it('uses overridden cwd option for each command if specified', () => {
     );
 });
 
+it('uses raw from options for each command', () => {
+    create(
+        [
+            { command: 'echo', env: { foo: 'bar' } },
+            { command: 'echo', env: { foo: 'baz' } },
+            'kill',
+        ],
+        {
+            raw: true,
+        }
+    );
+
+    expect(spawn).toHaveBeenCalledTimes(3);
+    expect(spawn).toHaveBeenCalledWith(
+        'echo',
+        expect.objectContaining({
+            env: expect.objectContaining({ foo: 'bar' }),
+            stdio: 'inherit',
+        })
+    );
+    expect(spawn).toHaveBeenCalledWith(
+        'echo',
+        expect.objectContaining({
+            env: expect.objectContaining({ foo: 'baz' }),
+            stdio: 'inherit',
+        })
+    );
+    expect(spawn).toHaveBeenCalledWith(
+        'kill',
+        expect.objectContaining({
+            env: expect.not.objectContaining({ foo: expect.anything() }),
+            stdio: 'inherit',
+        })
+    );
+});
+
+it('uses overridden raw option for each command if specified', () => {
+    create([{ command: 'echo', raw: false }, { command: 'echo' }], {
+        raw: true,
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(spawn).toHaveBeenCalledWith(
+        'echo',
+        expect.not.objectContaining({
+            stdio: expect.anything(),
+        })
+    );
+    expect(spawn).toHaveBeenCalledWith(
+        'echo',
+        expect.objectContaining({
+            stdio: 'inherit',
+        })
+    );
+});
+
 it('argument placeholders are properly replaced when additional arguments are passed', () => {
     create(
         [

--- a/src/concurrently.spec.ts
+++ b/src/concurrently.spec.ts
@@ -254,36 +254,20 @@ it('uses overridden cwd option for each command if specified', () => {
 });
 
 it('uses raw from options for each command', () => {
-    create(
-        [
-            { command: 'echo', env: { foo: 'bar' } },
-            { command: 'echo', env: { foo: 'baz' } },
-            'kill',
-        ],
-        {
-            raw: true,
-        }
-    );
+    create([{ command: 'echo' }, 'kill'], {
+        raw: true,
+    });
 
-    expect(spawn).toHaveBeenCalledTimes(3);
+    expect(spawn).toHaveBeenCalledTimes(2);
     expect(spawn).toHaveBeenCalledWith(
         'echo',
         expect.objectContaining({
-            env: expect.objectContaining({ foo: 'bar' }),
-            stdio: 'inherit',
-        })
-    );
-    expect(spawn).toHaveBeenCalledWith(
-        'echo',
-        expect.objectContaining({
-            env: expect.objectContaining({ foo: 'baz' }),
             stdio: 'inherit',
         })
     );
     expect(spawn).toHaveBeenCalledWith(
         'kill',
         expect.objectContaining({
-            env: expect.not.objectContaining({ foo: expect.anything() }),
             stdio: 'inherit',
         })
     );

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -162,7 +162,7 @@ export function concurrently(
                     ...command,
                 },
                 getSpawnOpts({
-                    raw: command.raw !== undefined ? command.raw : options.raw,
+                    raw: command.raw ?? options.raw,
                     env: command.env,
                     cwd: command.cwd || options.cwd,
                 }),

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -162,7 +162,7 @@ export function concurrently(
                     ...command,
                 },
                 getSpawnOpts({
-                    raw: options.raw,
+                    raw: command.raw !== undefined ? command.raw : options.raw,
                     env: command.env,
                     cwd: command.cwd || options.cwd,
                 }),
@@ -233,6 +233,11 @@ function mapToCommandInfo(command: ConcurrentlyCommandInput): CommandInfo {
         ...(command.prefixColor
             ? {
                   prefixColor: command.prefixColor,
+              }
+            : {}),
+        ...(command.raw !== undefined
+            ? {
+                  raw: command.raw,
               }
             : {}),
     };


### PR DESCRIPTION
In our setup, one of the processes is a docker compose process.
For this process we want to have `raw` output, but for other processes we would still like to have prefixes and colors.

I also removed one unused property. If you don't want that I can also take that commit out.

Thanks in advance