### PR TITLE
fix(suggestion): prefixColors API type to embrace string type

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ For more details, visit https://github.com/open-cli-tools/concurrently
   - `prefix`: the prefix type to use when logging processes output.
     Possible values: `index`, `pid`, `time`, `command`, `name`, `none`, or a template (eg `[{time} process: {pid}]`).
     Default: the name of the process, or its index if no name is set.
-  - `prefixColors`: a list of colors as supported by [chalk](https://www.npmjs.com/package/chalk) or `auto` for an automatically picked color.
+  - `prefixColors`: a list of colors or a string as supported by [chalk](https://www.npmjs.com/package/chalk) and additional style `auto` for an automatically picked color.
     If concurrently would run more commands than there are colors, the last color is repeated, unless if the last color value is `auto` which means following colors are automatically picked to vary.
     Prefix colors specified per-command take precedence over this list.
   - `prefixLength`: how many characters to show when prefixing with `command`. Default: `10`

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -62,9 +62,22 @@ export type ConcurrentlyOptions = {
     group?: boolean;
 
     /**
-     * Comma-separated list of chalk colors to use on prefixes.
+     * A comma-separated list of chalk colors or a string for available styles listed below to use on prefixes.
+     * If there are more commands than colors, the last color will be repeated.
+     *
+     * Available modifiers:
+     * - `reset`, `bold`, `dim`, `italic`, `underline`, `inverse`, `hidden`, `strikethrough`
+     *
+     * Available colors:
+     * - `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`,
+     * any hex values for colors (e.g. `#23de43`) or `auto` for an automatically picked color
+     *
+     * Available background colors:
+     * - `bgBlack`, `bgRed`, `bgGreen`, `bgYellow`, `bgBlue`, `bgMagenta`, `bgCyan`, `bgWhite`
+     *
+     * @see {@link https://www.npmjs.com/package/chalk} for more information.
      */
-    prefixColors?: string[];
+    prefixColors?: string | string[];
 
     /**
      * Maximum number of commands to run at once.

--- a/src/prefix-color-selector.ts
+++ b/src/prefix-color-selector.ts
@@ -58,8 +58,9 @@ function* createColorGenerator(customColors: string[]): Generator<string, string
 export class PrefixColorSelector {
     private colorGenerator: Generator<string, string>;
 
-    constructor(customColors: string[] = []) {
-        this.colorGenerator = createColorGenerator(customColors);
+    constructor(customColors: string | string[] = []) {
+        const normalizedColors = typeof customColors === 'string' ? [customColors] : customColors;
+        this.colorGenerator = createColorGenerator(normalizedColors);
     }
 
     /** A list of colors that are readable in a terminal. */


### PR DESCRIPTION
## Purpose of this PR
Regarding [`prefixColors`'s default value](https://github.com/open-cli-tools/concurrently/blob/16182089336827900ef2fc943b353c14b850cc9b/src/defaults.ts#L38), and the issue #437, though the document specified as below,

```
a list of colors as supported by chalk or auto for an automatically picked color.
```

still the behavior for using API doesn't look quite neat. Here's an example:

### example
```js
// referred code from README

const concurrently = require('concurrently');
const { result } = concurrently(
  [
    'npm:watch-*',
    { command: 'nodemon', name: 'server' },
    { command: 'deploy', name: 'deploy', env: { PUBLIC_KEY: '...' } },
    {
      command: 'watch',
      name: 'watch',
      cwd: path.resolve(__dirname, 'scripts/watchers'),
    },
  ],
  {
    prefix: 'name',
    killOthers: ['failure', 'success'],
    restartTries: 3,
    cwd: path.resolve(__dirname, 'scripts'),
    prefixColors: ['auto'],     //  <--------- To use 'auto' option, it needs to be wrapped in a list
  },
);
result.then(success, failure);
```

and as the option is `prefixColor"s"`, it makes sense. 

But it's literally an `auto` so rather than wrapping it in a list, 

```js
prefixColors: 'auto' // or 'bgMagenta', 'red', 'underline', ... for other available styles
```

just give it a string like above might not hurt the philosophy of [`prefixColors`'s default value](https://github.com/open-cli-tools/concurrently/blob/16182089336827900ef2fc943b353c14b850cc9b/src/defaults.ts#L38).

So it might be another handy option for users I guess. Or how do you think about this?

<br />   

## What's been updated
So I'm suggesting the `string` type to be able to embrace all the behaviors from users.
```diff
// src/concurrently.ts

- prefixColors?: string[];
+ prefixColors?: string | string[];
```

<br />   

<img width="950" alt="concurrently" src="https://github.com/open-cli-tools/concurrently/assets/63793178/b9fbbb5f-03ae-4d98-9dec-abafff9122cf">

and updated document for more details.
