### PR TITLE
Fix default export returning undefined in ESM 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,13 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+        # Bun does not currently fully support Windows:
+        # https://bun.sh/docs/installation#windows
+      - uses: oven-sh/setup-bun@v1
+        if: ${{ matrix.os.name != 'Windows' }}
+        with:
+          bun-version: latest
+
       - name: Setup pnpm
         uses: ./.github/actions/setup-pnpm
 
@@ -58,6 +65,24 @@ jobs:
 
       - name: Build & Test
         run: concurrently --prefix none --group "pnpm:build" "pnpm:test"
+
+      - name: Node import with CJS
+        run: node ./smoke-tests/smoke-test-cjs.cjs
+
+      - name: Node import with ESM
+        run: node ./smoke-tests/smoke-test-esm.mjs
+
+      - name: Bun import with CJS
+        if: ${{ matrix.os.name != 'Windows'}}
+        run: bun ./smoke-tests/smoke-test-cjs.cjs
+
+      - name: Bun import with ESM
+        if: ${{ matrix.os.name != 'Windows'}}
+        run: bun ./smoke-tests/smoke-test-esm.mjs
+
+      - name: Bun import with both CJS and ESM vis TS
+        if: ${{ matrix.os.name != 'Windows'}}
+        run: bun ./smoke-tests/smoke-test.ts
 
       - name: Submit coverage
         uses: coverallsapp/github-action@master

--- a/index.mjs
+++ b/index.mjs
@@ -7,4 +7,6 @@ import concurrently from './dist/src/index.js';
 // NOTE: the star reexport doesn't work in Node <12.20, <14.13 and <15.
 export * from './dist/src/index.js';
 
-export default concurrently.default;
+// In some cases, like with Bun, `default` is undefined and the function itself is
+// safely accessible via `concurrently`.
+export default concurrently.default || concurrently;

--- a/smoke-tests/smoke-test-cjs.cjs
+++ b/smoke-tests/smoke-test-cjs.cjs
@@ -4,21 +4,11 @@
 const assert = require('node:assert');
 const concurrently = require('../index.js');
 
-(async () => {
-  try {
-    // Assert the functions loaded by checking their names load and types are correct
-    assert.strictEqual(
-      typeof concurrently === 'function',
-      true,
-      'Expected default to be function',
-    );
+// Assert the functions loaded by checking their names load and types are correct
+assert.strictEqual(
+  typeof concurrently === 'function',
+  true,
+  'Expected default to be function',
+);
 
-    console.info('Imported cjs successfully');
-  } catch (error) {
-    console.error(error);
-    console.debug(error.stack);
-
-    // Prevent an unhandled rejection, exit gracefully.
-    process.exit(1);
-  }
-})();
+console.info('Imported cjs successfully');

--- a/smoke-tests/smoke-test-cjs.cjs
+++ b/smoke-tests/smoke-test-cjs.cjs
@@ -1,0 +1,24 @@
+// @ts-check
+/* eslint-disable @typescript-eslint/no-var-requires, no-console */
+
+const assert = require('node:assert');
+const concurrently = require('../index.js');
+
+(async () => {
+  try {
+    // Assert the functions loaded by checking their names load and types are correct
+    assert.strictEqual(
+      typeof concurrently === 'function',
+      true,
+      'Expected default to be function',
+    );
+
+    console.info('Imported cjs successfully');
+  } catch (error) {
+    console.error(error);
+    console.debug(error.stack);
+
+    // Prevent an unhandled rejection, exit gracefully.
+    process.exit(1);
+  }
+})();

--- a/smoke-tests/smoke-test-esm.mjs
+++ b/smoke-tests/smoke-test-esm.mjs
@@ -1,0 +1,25 @@
+// @ts-check
+/* eslint-disable no-console */
+
+import assert from 'node:assert';
+
+import concurrently from '../index.mjs';
+
+(async () => {
+    try {
+        // Assert the functions loaded by checking their names load and types are correct
+        assert.strictEqual(
+            typeof concurrently === 'function',
+            true,
+            'Expected default to be function',
+        );
+
+        console.info('Imported esm successfully');
+    } catch (error) {
+        console.error(error);
+        console.debug(error.stack);
+
+        // Prevent an unhandled rejection, exit gracefully.
+        process.exit(1);
+    }
+})();

--- a/smoke-tests/smoke-test-esm.mjs
+++ b/smoke-tests/smoke-test-esm.mjs
@@ -5,21 +5,7 @@ import assert from 'node:assert';
 
 import concurrently from '../index.mjs';
 
-(async () => {
-    try {
-        // Assert the functions loaded by checking their names load and types are correct
-        assert.strictEqual(
-            typeof concurrently === 'function',
-            true,
-            'Expected default to be function',
-        );
+// Assert the functions loaded by checking their names load and types are correct
+assert.strictEqual(typeof concurrently === 'function', true, 'Expected default to be function');
 
-        console.info('Imported esm successfully');
-    } catch (error) {
-        console.error(error);
-        console.debug(error.stack);
-
-        // Prevent an unhandled rejection, exit gracefully.
-        process.exit(1);
-    }
-})();
+console.info('Imported esm successfully');

--- a/smoke-tests/smoke-test.ts
+++ b/smoke-tests/smoke-test.ts
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+
+import assert from 'node:assert';
+
+(async () => {
+    try {
+        const { default: esm } = await import('../index.mjs');
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { default: cjs } = require('../index.js');
+
+        // Assert the functions loaded by checking their names load and types are correct
+        assert.strictEqual(typeof esm === 'function', true, 'Expected esm default to be function');
+        assert.strictEqual(typeof cjs === 'function', true, 'Expected cjs default to be function');
+
+        console.info('Imported with both CJS and ESM successfully');
+    } catch (error) {
+        console.error(error);
+        console.debug(error.stack);
+
+        // Prevent an unhandled rejection, exit gracefully.
+        process.exit(1);
+    }
+})();


### PR DESCRIPTION
I noticed this previously but it's consistently reproducible with Bun.

The esm based `index.mjs` export for `concurrently`, `export default concurrently.default`, in some cases depending on the way you're executing `concurrently` can have the default function on `concurrently` itself which makes this export not work as expect, as `default` is undefined.

This PR adds a simple fallback `export default concurrently.default || concurrently` that allows _some_ defense against this behaviour.

I have added tests for both Node and Bun that test the `commonjs` and `esm` import behaviour, as well as a direct `ts` import case testing both for Bun's case.

Also, I've noticed Node 19 is targetted here but Node 20 enters LTS next month, should this target 20 instead of 19?