### PR TITLE
Replace `date-fns` by `date-and-time-formatter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,10 @@ concurrently [options] <command ...>
 
 General
   -m, --max-processes          How many processes should run at once.
-                               Exact number or a percent of CPUs available (for example "50%").
                                New processes only spawn after all restart tries
-                               of a process.                            [string]
+                               of a process.
+                               Exact number or a percent of CPUs available (for
+                               example "50%")                           [string]
   -n, --names                  List of custom names to be used in prefix
                                template.
                                Example names: "main,browser,server"     [string]
@@ -202,7 +203,7 @@ Prefix styling
                           in prefix. The option can be used to shorten the
                           prefix when it is set to "command"
                                                           [number] [default: 10]
-  -t, --timestamp-format  Specify the timestamp in moment/date-fns format.
+  -t, --timestamp-format  Specify the timestamp in Unicode LDML format.
                                    [string] [default: "yyyy-MM-dd HH:mm:ss.SSS"]
 
 Input handling
@@ -219,8 +220,9 @@ Killing other processes
   -k, --kill-others          Kill other processes if one exits or dies.[boolean]
       --kill-others-on-fail  Kill other processes if one exits with non zero
                              status code.                              [boolean]
-      --kill-signal          Signal to send to other processes if one exits or dies.
-                             (SIGTERM/SIGKILL, defaults to SIGTERM)    [string]
+      --kill-signal, --ks    Signal to send to other processes if one exits or
+                             dies. (SIGTERM/SIGKILL, defaults to SIGTERM)
+                                                                        [string]
 
 Restarting
       --restart-tries  How many times a process that died should restart.
@@ -346,7 +348,7 @@ For more details, visit https://github.com/open-cli-tools/concurrently
     Anything else means all processes should exit successfully.
   - `restartTries`: how many attempts to restart a process that dies will be made. Default: `0`.
   - `restartDelay`: how many milliseconds to wait between process restarts. Default: `0`.
-  - `timestampFormat`: a [date-fns format](https://date-fns.org/v2.0.1/docs/format)
+  - `timestampFormat`: a [Unicode LDML format](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)
     to use when prefixing with `time`. Default: `yyyy-MM-dd HH:mm:ss.ZZZ`
   - `additionalArguments`: list of additional arguments passed that will get replaced in each command. If not defined, no argument replacing will happen.
 

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -151,7 +151,7 @@ const args = yargs(argsBeforeSep)
         },
         'timestamp-format': {
             alias: 't',
-            describe: 'Specify the timestamp in moment/date-fns format.',
+            describe: 'Specify the timestamp in Unicode LDML format.',
             default: defaults.timestampFormat,
             type: 'string',
         },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.1.2",
-    "date-fns": "^2.30.0",
+    "date-and-time-formatter": "^1.0.0",
     "lodash": "^4.17.21",
     "rxjs": "^7.8.1",
     "shell-quote": "^1.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ dependencies:
   chalk:
     specifier: ^4.1.2
     version: 4.1.2
-  date-fns:
-    specifier: ^2.30.0
-    version: 2.30.0
+  date-and-time-formatter:
+    specifier: ^1.0.0
+    version: 1.0.0
   lodash:
     specifier: ^4.17.21
     version: 4.17.21
@@ -425,13 +425,6 @@ packages:
       '@babel/core': 7.20.7(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
-
-  /@babel/runtime@7.22.5:
-    resolution: {integrity: sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: 0.13.11
-    dev: false
 
   /@babel/template@7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -2005,11 +1998,9 @@ packages:
       ctrlc-wrapper-windows-64: 0.0.2
     dev: true
 
-  /date-fns@2.30.0:
-    resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
-    engines: {node: '>=0.11'}
-    dependencies:
-      '@babel/runtime': 7.22.5
+  /date-and-time-formatter@1.0.0:
+    resolution: {integrity: sha512-ZZU2nZTd02XuWszGPaggHiAtMnnAQTv7O+A2HSoBLuAepCBBIs2FiiSqih4B4QR8be0uq2+toSiTFJtt9j/pkA==}
+    engines: {node: '>=16.14'}
     dev: false
 
   /debug@3.2.7(supports-color@8.1.1):
@@ -4202,10 +4193,6 @@ packages:
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
-
-  /regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-    dev: false
 
   /regexp.prototype.flags@1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -61,7 +61,7 @@ export const success = 'all' as SuccessCondition;
 
 /**
  * Date format used when logging date/time.
- * @see https://date-fns.org/v2.0.1/docs/format
+ * @see https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
  */
 export const timestampFormat = 'yyyy-MM-dd HH:mm:ss.SSS';
 

--- a/src/flow-control/log-timings.spec.ts
+++ b/src/flow-control/log-timings.spec.ts
@@ -1,4 +1,4 @@
-import formatDate from 'date-fns/format';
+import { formatDateTime } from 'date-and-time-formatter';
 import { createMockInstance } from 'jest-create-mock-instance';
 
 import { CloseEvent } from '../command';
@@ -79,22 +79,22 @@ it('logs the timings at the start and end (ie complete or error) event of each c
 
     expect(logger.logCommandEvent).toHaveBeenCalledTimes(4);
     expect(logger.logCommandEvent).toHaveBeenCalledWith(
-        `${commands[0].command} started at ${formatDate(startDate0, timestampFormat)}`,
+        `${commands[0].command} started at ${formatDateTime(startDate0, timestampFormat)}`,
         commands[0],
     );
     expect(logger.logCommandEvent).toHaveBeenCalledWith(
-        `${commands[1].command} started at ${formatDate(startDate1, timestampFormat)}`,
+        `${commands[1].command} started at ${formatDateTime(startDate1, timestampFormat)}`,
         commands[1],
     );
     expect(logger.logCommandEvent).toHaveBeenCalledWith(
-        `${commands[1].command} stopped at ${formatDate(
+        `${commands[1].command} stopped at ${formatDateTime(
             endDate1,
             timestampFormat,
         )} after ${command1DurationTextMs}`,
         commands[1],
     );
     expect(logger.logCommandEvent).toHaveBeenCalledWith(
-        `${commands[0].command} stopped at ${formatDate(
+        `${commands[0].command} stopped at ${formatDateTime(
             endDate0,
             timestampFormat,
         )} after ${command0DurationTextMs}`,

--- a/src/flow-control/log-timings.ts
+++ b/src/flow-control/log-timings.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import formatDate from 'date-fns/format';
+import { formatDateTime } from 'date-and-time-formatter';
 import _ from 'lodash';
 import * as Rx from 'rxjs';
 import { bufferCount, combineLatestWith, take } from 'rxjs/operators';
@@ -77,14 +77,14 @@ export class LogTimings implements FlowController {
         commands.forEach((command) => {
             command.timer.subscribe(({ startDate, endDate }) => {
                 if (!endDate) {
-                    const formattedStartDate = formatDate(startDate, this.timestampFormat);
+                    const formattedStartDate = formatDateTime(startDate, this.timestampFormat);
                     logger.logCommandEvent(
                         `${command.command} started at ${formattedStartDate}`,
                         command,
                     );
                 } else {
                     const durationMs = endDate.getTime() - startDate.getTime();
-                    const formattedEndDate = formatDate(endDate, this.timestampFormat);
+                    const formattedEndDate = formatDateTime(endDate, this.timestampFormat);
                     logger.logCommandEvent(
                         `${
                             command.command

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export type ConcurrentlyOptions = BaseConcurrentlyOptions & {
 
     /**
      * Date format used when logging date/time.
-     * @see https://date-fns.org/v2.0.1/docs/format
+     * @see https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
      */
     timestampFormat?: string;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import formatDate from 'date-fns/format';
+import { formatDateTime } from 'date-and-time-formatter';
 import _ from 'lodash';
 import * as Rx from 'rxjs';
 
@@ -56,7 +56,7 @@ export class Logger {
 
         /**
          * Date format used when logging date/time.
-         * @see https://date-fns.org/v2.0.1/docs/format
+         * @see https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
          */
         timestampFormat?: string;
     }) {
@@ -93,7 +93,7 @@ export class Logger {
             index: String(command.index),
             name: command.name,
             command: this.shortenText(command.command),
-            time: formatDate(Date.now(), this.timestampFormat),
+            time: formatDateTime(new Date(), this.timestampFormat),
         };
     }
 


### PR DESCRIPTION
Fixes #436

Backwards-compatible because `date-fns` follows Unicode LDML too (well, more or less https://blog.date-fns.org/v2-unicode-tokens/)