### PR TITLE
Add a state property to Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,11 @@ It has the following properties:
 - `cwd`: the current working directory of the command.
 - `env`: an object with all the environment variables that the command will be spawned with.
 - `killed`: whether the command has been killed.
-- `exited`: whether the command exited yet.
+- `state`: the command's state. Can be one of
+  - `stopped`: if the command was never started
+  - `started`: if the command is currently running
+  - `errored`: if the command failed spawning
+  - `exited`: if the command is not running anymore, e.g. it received a close event
 - `pid`: the command's process ID.
 - `stdin`: a Writable stream to the command's `stdin`.
 - `stdout`: an RxJS observable to the command's `stdout`.

--- a/src/output-writer.spec.ts
+++ b/src/output-writer.spec.ts
@@ -15,7 +15,7 @@ function createWriter(overrides?: { group: boolean }) {
 }
 
 function closeCommand(command: FakeCommand) {
-    command.exited = true;
+    command.state = 'exited';
     command.close.next(createFakeCloseEvent({ command, index: command.index }));
 }
 

--- a/src/output-writer.ts
+++ b/src/output-writer.ts
@@ -33,7 +33,8 @@ export class OutputWriter {
                 for (let i = command.index + 1; i < commands.length; i++) {
                     this.activeCommandIndex = i;
                     this.flushBuffer(i);
-                    if (!commands[i].exited) {
+                    // TODO: Should errored commands also flush buffer?
+                    if (commands[i].state !== 'exited') {
                         break;
                     }
                 }


### PR DESCRIPTION
Title.
The intention is that this will make it easier to tell exactly where the command is. My idea is that it can be used for #433, since it might be necessary to make a distinction between a command that was never started, and everything else.

Also marked it a breaking change because I removed the `#exited` property, as `#state` supersedes it.
Booleans do a poor job sometimes :)

Most LOC in this PR are coming from moving a few tests around.