### PR TITLE
Export named concurrently + fix TS errors with Node16

### DIFF
--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -3,7 +3,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import * as defaults from '../src/defaults';
-import concurrently from '../src/index';
+import { concurrently } from '../src/index';
 import { epilogue } from './epilogue';
 
 // Clean-up arguments (yargs expects only the arguments after the program name)

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,0 +1,7 @@
+/*
+ * While in local development, make sure you've run `pnpm run build` first.
+ */
+import { concurrently } from './dist/src/index.js';
+
+export * from './dist/src/index.js';
+export default concurrently;

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,7 +1,4 @@
-/*
- * While in local development, make sure you've run `pnpm run build` first.
- */
-import { concurrently } from './dist/src/index.js';
+import { concurrently } from './src/index.js';
 
-export * from './dist/src/index.js';
+export * from './src/index.js';
 export default concurrently;

--- a/index.d.mts
+++ b/index.d.mts
@@ -1,4 +1,7 @@
-import { concurrently } from './src/index.js';
+/*
+ * While in local development, make sure you've run `pnpm run build` first.
+ */
+import { concurrently } from './dist/src/index.js';
 
-export * from './src/index.js';
+export * from './dist/src/index.js';
 export default concurrently;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+/*
+ * While in local development, make sure you've run `pnpm run build` first.
+ */
+import { concurrently } from './dist/src/index.js';
+
+export * from './dist/src/index.js';
+export default concurrently;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,4 @@
-/*
- * While in local development, make sure you've run `pnpm run build` first.
- */
-import { concurrently } from './dist/src/index.js';
+import { concurrently } from './src/index.js';
 
-export * from './dist/src/index.js';
+export * from './src/index.js';
 export default concurrently;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,4 +4,8 @@
 import { concurrently } from './dist/src/index.js';
 
 export * from './dist/src/index.js';
+// @ts-expect-error ignore the usage of `export =` along with `export default`.
+// This is seemingly fine, but the file needs to be included in the TS project, which can't be done
+// due to importing from `dist`. See https://stackoverflow.com/q/42609768/2083599
+export = concurrently;
 export default concurrently;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,7 @@
-import { concurrently } from './src/index.js';
+/*
+ * While in local development, make sure you've run `pnpm run build` first.
+ */
+import { concurrently } from './dist/src/index.js';
 
-export * from './src/index.js';
+export * from './dist/src/index.js';
 export default concurrently;

--- a/index.js
+++ b/index.js
@@ -5,5 +5,5 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const concurrently = require('./dist/src/index.js');
 
-module.exports = exports = concurrently.default;
+module.exports = exports = concurrently;
 Object.assign(exports, concurrently);

--- a/index.js
+++ b/index.js
@@ -5,5 +5,10 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const concurrently = require('./dist/src/index.js');
 
+// For require()
 module.exports = exports = concurrently.concurrently;
+
+// For TS + import syntax; mimics `export default`
+exports.default = exports;
+
 Object.assign(exports, concurrently);

--- a/index.js
+++ b/index.js
@@ -5,5 +5,5 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const concurrently = require('./dist/src/index.js');
 
-module.exports = exports = concurrently;
+module.exports = exports = concurrently.concurrently;
 Object.assign(exports, concurrently);

--- a/index.mjs
+++ b/index.mjs
@@ -2,9 +2,9 @@
  * While in local development, make sure you've run `pnpm run build` first.
  */
 
-import concurrently from './dist/src/index.js';
+import { concurrently } from './dist/src/index.js';
 
 // NOTE: the star reexport doesn't work in Node <12.20, <14.13 and <15.
 export * from './dist/src/index.js';
 
-export default concurrently.default;
+export default concurrently;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.2.2",
   "description": "Run commands concurrently",
   "main": "index.js",
-  "types": "dist/src/index.d.ts",
+  "types": "index.d.ts",
   "type": "commonjs",
   "bin": {
     "concurrently": "./dist/bin/concurrently.js",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,9 @@
   "files": [
     "dist",
     "index.js",
+    "index.d.ts",
     "index.mjs",
+    "index.d.mts",
     "!**/fixtures",
     "!**/*.spec.js",
     "!**/*.spec.d.ts"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/src/index.d.ts",
-      "import": "./index.mjs",
-      "require": "./index.js",
-      "default": "./index.js"
+      "import": {
+        "types": "./index.d.mts",
+        "default": "./index.mjs"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      }
     },
     "./package.json": "./package.json"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Readable } from 'stream';
 
 import { CloseEvent, Command, CommandIdentifier, TimerEvent } from './command';
 import {
-    concurrently,
+    concurrently as createConcurrently,
     ConcurrentlyCommandInput,
     ConcurrentlyOptions as BaseConcurrentlyOptions,
     ConcurrentlyResult,
@@ -91,10 +91,10 @@ export type ConcurrentlyOptions = BaseConcurrentlyOptions & {
     additionalArguments?: string[];
 };
 
-export default (
+export function concurrently(
     commands: ConcurrentlyCommandInput[],
     options: Partial<ConcurrentlyOptions> = {},
-) => {
+) {
     const logger = new Logger({
         hide: options.hide,
         prefixFormat: options.prefix,
@@ -103,7 +103,7 @@ export default (
         timestampFormat: options.timestampFormat,
     });
 
-    return concurrently(commands, {
+    return createConcurrently(commands, {
         maxProcesses: options.maxProcesses,
         raw: options.raw,
         successCondition: options.successCondition,
@@ -141,28 +141,26 @@ export default (
         prefixColors: options.prefixColors || [],
         additionalArguments: options.additionalArguments,
     });
-};
+}
 
 // Export all flow controllers, types, and the main concurrently function,
 // so that 3rd-parties can use them however they want
+
+// Main
+export { ConcurrentlyCommandInput, ConcurrentlyResult, createConcurrently, Logger };
+
+// Command specific
+export { CloseEvent, Command, CommandIdentifier, TimerEvent };
+
+// Flow controllers
 export {
-    CloseEvent,
-    // Command specific
-    Command,
-    CommandIdentifier,
-    concurrently,
-    ConcurrentlyCommandInput,
-    ConcurrentlyResult,
-    // Flow controllers
     FlowController,
     InputHandler,
     KillOnSignal,
     KillOthers,
     LogError,
     LogExit,
-    Logger,
     LogOutput,
     LogTimings,
     RestartProcess,
-    TimerEvent,
 };


### PR DESCRIPTION
Fixes a bunch of issues when using concurrently
1. For `require()` function (from both TS and pure JS)
2. With TS + import syntax, but without ES module interop
3. With TS + import syntax, but with ES module interop
4. As an ES Module (from both TS and pure JS)

On the side, the named export `concurrently` is now the fully configured concurrently.
This was done to simplify the exports in the index files (most likely specific to ESM, but I've lost track of why exactly).

Will add some smoke tests in a follow up PR so that this one stays mostly focused to the core changes.

Fixes #399
Fixes #454
Closes #440 