### PR TITLE
Add @jest/types

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   },
   "devDependencies": {
     "@hirez_io/observer-spy": "^2.2.0",
+    "@jest/types": "^29.6.3",
     "@swc/core": "^1.3.93",
     "@swc/jest": "^0.2.29",
     "@types/jest": "^29.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.1'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.1'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 dependencies:
@@ -37,6 +37,9 @@ devDependencies:
   '@hirez_io/observer-spy':
     specifier: ^2.2.0
     version: 2.2.0(rxjs@7.8.1)(typescript@5.2.2)
+  '@jest/types':
+    specifier: ^29.6.3
+    version: 29.6.3
   '@swc/core':
     specifier: ^1.3.93
     version: 1.3.93
@@ -981,7 +984,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.1
-      '@types/node': 14.18.62
+      '@types/node': 16.18.59
       '@types/yargs': 17.0.29
       chalk: 4.1.2
     dev: true


### PR DESCRIPTION
Since we moved to pnpm, transitive dependencies aren't hoisted where possible anymore.
That's one of its selling points: https://pnpm.io/motivation#creating-a-non-flat-node_modules-directory
 
<img width="962" alt="Screenshot of terminal showing the list of dependencies that have 'jest' in their name" src="https://github.com/open-cli-tools/concurrently/assets/826553/2215e166-af1a-4222-a4b7-1cf8cfc36c72">

Because of this, jest.config.js typing wasn't working anymore, so adding this dev dependency should fix it at least in VS Code.