### PR TITLE
Abort commands not running when max processes < N

### DIFF
--- a/src/completion-listener.spec.ts
+++ b/src/completion-listener.spec.ts
@@ -47,7 +47,8 @@ describe('listen', () => {
 
     it('completes when abort signal is received and command is stopped, returns nothing', async () => {
         const abortCtrl = new AbortController();
-        const result = createController('all').listen([new FakeCommand()], abortCtrl.signal);
+        // Use success condition = first to test index access when there are no close events
+        const result = createController('first').listen([new FakeCommand()], abortCtrl.signal);
 
         abortCtrl.abort();
         scheduler.flush();

--- a/src/completion-listener.ts
+++ b/src/completion-listener.ts
@@ -126,11 +126,11 @@ export class CompletionListener {
                                 first.timings.endDate.getTime() - second.timings.endDate.getTime(),
                         ),
                 ),
-                switchMap((events) => {
-                    return this.isSuccess(events)
+                switchMap((events) =>
+                    this.isSuccess(events)
                         ? this.emitWithScheduler(Rx.of(events))
-                        : this.emitWithScheduler(Rx.throwError(() => events));
-                }),
+                        : this.emitWithScheduler(Rx.throwError(() => events)),
+                ),
                 take(1),
             ),
         );

--- a/src/concurrently.spec.ts
+++ b/src/concurrently.spec.ts
@@ -111,6 +111,16 @@ it('spawns commands up to percent based limit at once', () => {
     expect(spawn).toHaveBeenCalledWith('qux', expect.objectContaining({}));
 });
 
+it('does not spawn further commands on abort signal aborted', () => {
+    const abortController = new AbortController();
+    create(['foo', 'bar'], { maxProcesses: 1, abortSignal: abortController.signal });
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    abortController.abort();
+    processes[0].emit('close', 0, null);
+    expect(spawn).toHaveBeenCalledTimes(1);
+});
+
 it('runs controllers with the commands', () => {
     create(['echo', '"echo wrapped"']);
 

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -227,7 +227,7 @@ export function concurrently(
     }
 
     const result = new CompletionListener({ successCondition: options.successCondition })
-        .listen(commands)
+        .listen(commands, options.abortSignal)
         .finally(() => {
             handleResult.onFinishCallbacks.forEach((onFinish) => onFinish());
         });

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -43,7 +43,8 @@ export type ConcurrentlyResult = {
      * A promise that resolves when concurrently ran successfully according to the specified
      * success condition, or reject otherwise.
      *
-     * Both the resolved and rejected value is the list of all command's close events.
+     * Both the resolved and rejected value is a list of all the close events for commands that
+     * spawned; commands that didn't spawn are filtered out.
      */
     result: Promise<CloseEvent[]>;
 };

--- a/src/flow-control/kill-on-signal.spec.ts
+++ b/src/flow-control/kill-on-signal.spec.ts
@@ -51,29 +51,13 @@ it('returns commands that keep non-SIGINT exit codes', () => {
     expect(callback).toHaveBeenCalledWith(expect.objectContaining({ exitCode: 1 }));
 });
 
-it('kills all commands on SIGINT', () => {
-    controller.handle(commands);
-    process.emit('SIGINT');
+describe.each(['SIGINT', 'SIGTERM', 'SIGHUP'])('on %s', (signal) => {
+    it('kills all commands', () => {
+        controller.handle(commands);
+        process.emit(signal);
 
-    expect(process.listenerCount('SIGINT')).toBe(1);
-    expect(commands[0].kill).toHaveBeenCalledWith('SIGINT');
-    expect(commands[1].kill).toHaveBeenCalledWith('SIGINT');
-});
-
-it('kills all commands on SIGTERM', () => {
-    controller.handle(commands);
-    process.emit('SIGTERM');
-
-    expect(process.listenerCount('SIGTERM')).toBe(1);
-    expect(commands[0].kill).toHaveBeenCalledWith('SIGTERM');
-    expect(commands[1].kill).toHaveBeenCalledWith('SIGTERM');
-});
-
-it('kills all commands on SIGHUP', () => {
-    controller.handle(commands);
-    process.emit('SIGHUP');
-
-    expect(process.listenerCount('SIGHUP')).toBe(1);
-    expect(commands[0].kill).toHaveBeenCalledWith('SIGHUP');
-    expect(commands[1].kill).toHaveBeenCalledWith('SIGHUP');
+        expect(process.listenerCount(signal)).toBe(1);
+        expect(commands[0].kill).toHaveBeenCalledWith(signal);
+        expect(commands[1].kill).toHaveBeenCalledWith(signal);
+    });
 });

--- a/src/flow-control/kill-on-signal.ts
+++ b/src/flow-control/kill-on-signal.ts
@@ -10,9 +10,17 @@ import { FlowController } from './flow-controller';
  */
 export class KillOnSignal implements FlowController {
     private readonly process: EventEmitter;
+    private readonly abortController?: AbortController;
 
-    constructor({ process }: { process: EventEmitter }) {
+    constructor({
+        process,
+        abortController,
+    }: {
+        process: EventEmitter;
+        abortController?: AbortController;
+    }) {
         this.process = process;
+        this.abortController = abortController;
     }
 
     handle(commands: Command[]) {
@@ -20,6 +28,7 @@ export class KillOnSignal implements FlowController {
         (['SIGINT', 'SIGTERM', 'SIGHUP'] as NodeJS.Signals[]).forEach((signal) => {
             this.process.on(signal, () => {
                 caughtSignal = signal;
+                this.abortController?.abort();
                 commands.forEach((command) => command.kill(signal));
             });
         });

--- a/src/flow-control/kill-others.ts
+++ b/src/flow-control/kill-others.ts
@@ -12,19 +12,23 @@ export type ProcessCloseCondition = 'failure' | 'success';
  */
 export class KillOthers implements FlowController {
     private readonly logger: Logger;
+    private readonly abortController?: AbortController;
     private readonly conditions: ProcessCloseCondition[];
     private readonly killSignal: string | undefined;
 
     constructor({
         logger,
+        abortController,
         conditions,
         killSignal,
     }: {
         logger: Logger;
+        abortController?: AbortController;
         conditions: ProcessCloseCondition | ProcessCloseCondition[];
         killSignal: string | undefined;
     }) {
         this.logger = logger;
+        this.abortController = abortController;
         this.conditions = _.castArray(conditions);
         this.killSignal = killSignal;
     }
@@ -49,6 +53,8 @@ export class KillOthers implements FlowController {
 
         closeStates.forEach((closeState) =>
             closeState.subscribe(() => {
+                this.abortController?.abort();
+
                 const killableCommands = commands.filter((command) => Command.canKill(command));
                 if (killableCommands.length) {
                     this.logger.logGlobalEvent(

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import { LogTimings } from './flow-control/log-timings';
 import { RestartProcess } from './flow-control/restart-process';
 import { Logger } from './logger';
 
-export type ConcurrentlyOptions = BaseConcurrentlyOptions & {
+export type ConcurrentlyOptions = Omit<BaseConcurrentlyOptions, 'abortSignal'> & {
     // Logger options
     /**
      * Which command(s) should have their output hidden.
@@ -103,6 +103,8 @@ export default (
         timestampFormat: options.timestampFormat,
     });
 
+    const abortController = new AbortController();
+
     return concurrently(commands, {
         maxProcesses: options.maxProcesses,
         raw: options.raw,
@@ -111,6 +113,7 @@ export default (
         logger,
         outputStream: options.outputStream || process.stdout,
         group: options.group,
+        abortSignal: abortController.signal,
         controllers: [
             new LogError({ logger }),
             new LogOutput({ logger }),
@@ -122,7 +125,7 @@ export default (
                     options.inputStream || (options.handleInput ? process.stdin : undefined),
                 pauseInputStreamOnFinish: options.pauseInputStreamOnFinish,
             }),
-            new KillOnSignal({ process }),
+            new KillOnSignal({ process, abortController }),
             new RestartProcess({
                 logger,
                 delay: options.restartDelay,
@@ -132,6 +135,7 @@ export default (
                 logger,
                 conditions: options.killOthers || [],
                 killSignal: options.killSignal,
+                abortController,
             }),
             new LogTimings({
                 logger: options.timings ? logger : undefined,


### PR DESCRIPTION
## Problem
In a few issues, this situation came up where commands that haven't started yet will run anyways when they shouldn't even start.
Best examples of this are SIGINT and `--kill-others` combined with `--max-processes` that's lower than N (where N = number of commands itself).

For someone who pressed <kbd>Ctrl</kbd> + <kbd>C</kbd>, it could be annoying that one press isn't sufficient and they have to press it up to N times (see #452).

For `--kill-others`/`--kill-others-on-fail`, it, well... just doesn't work (see #433).

## Solution

With SIGINT, it's quite clear that commands awaiting their turn should be aborted.

For `--kill-others`, there was a possible interaction with `--restart-tries`: should it be respected at all?
But the flag is documented as _"restart processes that died"_, which isn't the case of a command that never started. Therefore I made the decision of also aborting these commands.

Now, aborting the commands is done here by using an `AbortController`.
It's quite simple: flow controllers make use of it, and concurrently stops further spawning of processes if the signal is already aborted.

> [!NOTE]
> `AbortController` is built into Node 15+, which is a requirement for concurrently 9.0.0 (#448), therefore this PR is a breaking change.

---

Fixes #433 
Fixes #452 