### PR TITLE
Don't override errored state on close event

### DIFF
--- a/src/command.spec.ts
+++ b/src/command.spec.ts
@@ -151,6 +151,14 @@ describe('#start()', () => {
             expect(command.state).toBe('exited');
         });
 
+        it('does not change state if there was an error', () => {
+            const { command } = createCommand();
+            command.start();
+            process.emit('error', 'foo');
+            process.emit('close', 0, null);
+            expect(command.state).toBe('errored');
+        });
+
         it('shares start and close timing events to the timing stream', async () => {
             const { command, values } = createCommand();
             const startDate = new Date();

--- a/src/command.ts
+++ b/src/command.ts
@@ -169,7 +169,11 @@ export class Command implements CommandInfo {
             .pipe(Rx.map((event) => event as [number | null, NodeJS.Signals | null]))
             .subscribe(([exitCode, signal]) => {
                 this.process = undefined;
-                this.state = 'exited';
+
+                // Don't override error event
+                if (this.state !== 'errored') {
+                    this.state = 'exited';
+                }
 
                 const endDate = new Date(Date.now());
                 this.timer.next({ startDate, endDate });


### PR DESCRIPTION
Fixes oversight from #455 