### PR TITLE
Update `spawn-command` for valid license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "lodash": "^4.17.21",
     "rxjs": "^7.8.1",
     "shell-quote": "^1.8.1",
-    "spawn-command": "0.0.2",
+    "spawn-command": "0.0.2-1",
     "supports-color": "^8.1.1",
     "tree-kill": "^1.2.2",
     "yargs": "^17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ dependencies:
     specifier: ^1.8.1
     version: 1.8.1
   spawn-command:
-    specifier: 0.0.2
-    version: 0.0.2
+    specifier: 0.0.2-1
+    version: 0.0.2-1
   supports-color:
     specifier: ^8.1.1
     version: 8.1.1
@@ -4386,8 +4386,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /spawn-command@0.0.2:
-    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
+  /spawn-command@0.0.2-1:
+    resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}
     dev: false
 
   /sprintf-js@1.0.3:


### PR DESCRIPTION
`0.0.2-1` is equivalent to `0.0.2` except that it has an explicit `license` field in the `package.json` [1], which is needed for easy automated license tracking.

It looks like `concurrently` accidentally downgraded to the old version in this PR [2]

[1] https://github.com/mmalecki/spawn-command/compare/v0.0.2...v0.0.2-1
[2] https://github.com/open-cli-tools/concurrently/commit/d1fd1a8528d60cbc378b8f050332b92788d22a22#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R58