### PR TITLE
Improve examples for the `--passthrough-arguments` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,14 +297,17 @@ Examples:
  - Passthrough some additional arguments via '{<number>}' placeholder
 
      $ concurrently -P "echo {1}" -- foo
+     # Results in: echo foo
 
  - Passthrough all additional arguments via '{@}' placeholder
 
      $ concurrently -P "npm:dev-* -- {@}" -- --watch --noEmit
+     # Results in something like: npm run dev-example -- --watch --noEmit
 
- - Passthrough all additional arguments combined via '{*}' placeholder
+ - Passthrough all additional arguments combined into one argument via '{*}' placeholder
 
-     $ concurrently -P "npm:dev-* -- {*}" -- --watch --noEmit
+     $ concurrently -P "echo {*}" -- foo bar
+     # Results in: echo 'foo bar'
 
 For more details, visit https://github.com/open-cli-tools/concurrently
 ```

--- a/bin/epilogue.ts
+++ b/bin/epilogue.ts
@@ -71,7 +71,8 @@ const examples = [
         ].join('\n'),
     },
     {
-        description: "Passthrough all additional arguments combined into one argument via '{*}' placeholder",
+        description:
+            "Passthrough all additional arguments combined into one argument via '{*}' placeholder",
         example: ['$ $0 -P "echo {*}" -- foo bar', "# Results in: echo 'foo bar'"].join('\n'),
     },
 ];

--- a/bin/epilogue.ts
+++ b/bin/epilogue.ts
@@ -61,15 +61,18 @@ const examples = [
     },
     {
         description: "Passthrough some additional arguments via '{<number>}' placeholder",
-        example: '$ $0 -P "echo {1}" -- foo',
+        example: ['$ $0 -P "echo {1}" -- foo bar', '# Results in: echo foo'].join('\n'),
     },
     {
         description: "Passthrough all additional arguments via '{@}' placeholder",
-        example: '$ $0 -P "npm:dev-* -- {@}" -- --watch --noEmit',
+        example: [
+            '$ $0 -P "npm:dev-* -- {@}" -- --watch --noEmit',
+            '# Results in something like: npm run dev-example -- --watch --noEmit',
+        ].join('\n'),
     },
     {
-        description: "Passthrough all additional arguments combined via '{*}' placeholder",
-        example: '$ $0 -P "npm:dev-* -- {*}" -- --watch --noEmit',
+        description: "Passthrough all additional arguments combined into one argument via '{*}' placeholder",
+        example: ['$ $0 -P "echo {*}" -- foo bar', "# Results in: echo 'foo bar'"].join('\n'),
     },
 ];
 


### PR DESCRIPTION
The existing examples are quite vague and do not fully describe how the feature works

The improved examples I've added here were taken directly from the original PR implementing this feature:
https://github.com/open-cli-tools/concurrently/pull/307