### PR TITLE
Inter-Process Communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ For more details, visit https://github.com/open-cli-tools/concurrently
 ### `concurrently(commands[, options])`
 
 - `commands`: an array of either strings (containing the commands to run) or objects
-  with the shape `{ command, name, prefixColor, env, cwd }`.
+  with the shape `{ command, name, prefixColor, env, cwd, ipc }`.
 
 - `options` (optional): an object containing any of the below:
   - `cwd`: the working directory to be used by all commands. Can be overriden per command.

--- a/README.md
+++ b/README.md
@@ -405,10 +405,32 @@ It has the following properties:
 - `stderr`: an RxJS observable to the command's `stderr`.
 - `error`: an RxJS observable to the command's error events (e.g. when it fails to spawn).
 - `timer`: an RxJS observable to the command's timing events (e.g. starting, stopping).
+- `messages`: an object with the following properties:
+
+  - `incoming`: an RxJS observable for the IPC messages received from the underlying process.
+  - `outgoing`: an RxJS observable for the IPC messages sent to the underlying process.
+
+  Both observables emit [`MessageEvent`](#messageevent)s.<br>
+  Note that if the command wasn't spawned with IPC support, these won't emit any values.
+
 - `close`: an RxJS observable to the command's close events.
   See [`CloseEvent`](#CloseEvent) for more information.
-- `start()`: starts the command, setting up all
+- `start()`: starts the command and sets up all of the above streams
+- `send(message[, handle, options])`: sends a message to the underlying process via IPC channels,
+  returning a promise that resolves once the message has been sent.
+  See [Node.js docs](https://nodejs.org/docs/latest/api/child_process.html#subprocesssendmessage-sendhandle-options-callback).
 - `kill([signal])`: kills the command, optionally specifying a signal (e.g. `SIGTERM`, `SIGKILL`, etc).
+
+### `MessageEvent`
+
+An object that represents a message that was received from/sent to the underlying command process.<br>
+It has the following properties:
+
+- `message`: the message itself.
+- `handle`: a [`net.Socket`](https://nodejs.org/docs/latest/api/net.html#class-netsocket),
+  [`net.Server`](https://nodejs.org/docs/latest/api/net.html#class-netserver) or
+  [`dgram.Socket`](https://nodejs.org/docs/latest/api/dgram.html#class-dgramsocket),
+  if one was sent, or `undefined`.
 
 ### `CloseEvent`
 

--- a/src/command.spec.ts
+++ b/src/command.spec.ts
@@ -335,6 +335,15 @@ describe('#start()', () => {
             );
         });
 
+        it('sends the message to the process, if it starts late', () => {
+            const { command } = createCommand({ ipc: true });
+            command.messages.outgoing.next({ message: {}, onSent() {} });
+            expect(process.send).not.toHaveBeenCalled();
+
+            command.start();
+            expect(process.send).toHaveBeenCalled();
+        });
+
         it('calls onSent with the result of sending the message', () => {
             const { command } = createCommand({ ipc: true });
             command.start();

--- a/src/command.spec.ts
+++ b/src/command.spec.ts
@@ -366,7 +366,7 @@ describe('#start()', () => {
 
 describe('#send()', () => {
     it('throws if IPC is not set up', () => {
-        const { command } = createCommand({ ipc: IPC_FD });
+        const { command } = createCommand();
         const fn = () => command.send({});
         expect(fn).toThrow();
     });

--- a/src/command.ts
+++ b/src/command.ts
@@ -274,7 +274,7 @@ export class Command implements CommandInfo {
      *          or rejects if it fails to deliver the message.
      */
     send(message: object, handle?: SendHandle, options?: MessageOptions): Promise<void> {
-        if (!this.ipc) {
+        if (this.ipc == null) {
             throw new Error('Command IPC is disabled');
         }
         return new Promise((resolve, reject) => {

--- a/src/command.ts
+++ b/src/command.ts
@@ -267,7 +267,7 @@ export class Command implements CommandInfo {
     }
 
     /**
-     * Sends a message to the underlying process.
+     * Sends a message to the underlying process once it starts.
      *
      * @throws  If the command doesn't have an IPC channel enabled
      * @returns Promise that resolves when the message is sent,

--- a/src/command.ts
+++ b/src/command.ts
@@ -40,11 +40,11 @@ export interface CommandInfo {
 
     /**
      * Whether sending of messages to/from this command (also known as "inter-process communication")
-     * should be enabled.
+     * should be enabled, and using which file descriptor number.
      *
-     * @default false
+     * If set, must be > 2.
      */
-    ipc?: boolean;
+    ipc?: number;
 
     /**
      * Output command in raw format.
@@ -140,7 +140,7 @@ export class Command implements CommandInfo {
     readonly cwd?: string;
 
     /** @inheritdoc */
-    readonly ipc?: boolean = false;
+    readonly ipc?: number;
 
     readonly close = new Rx.Subject<CloseEvent>();
     readonly error = new Rx.Subject<unknown>();

--- a/src/concurrently.spec.ts
+++ b/src/concurrently.spec.ts
@@ -272,13 +272,13 @@ it('uses raw from options for each command', () => {
     expect(spawn).toHaveBeenCalledWith(
         'echo',
         expect.objectContaining({
-            stdio: 'inherit',
+            stdio: ['inherit', 'inherit', 'inherit'],
         }),
     );
     expect(spawn).toHaveBeenCalledWith(
         'kill',
         expect.objectContaining({
-            stdio: 'inherit',
+            stdio: ['inherit', 'inherit', 'inherit'],
         }),
     );
 });
@@ -292,13 +292,13 @@ it('uses overridden raw option for each command if specified', () => {
     expect(spawn).toHaveBeenCalledWith(
         'echo',
         expect.objectContaining({
-            stdio: 'pipe',
+            stdio: ['pipe', 'pipe', 'pipe'],
         }),
     );
     expect(spawn).toHaveBeenCalledWith(
         'echo',
         expect.objectContaining({
-            stdio: 'inherit',
+            stdio: ['inherit', 'inherit', 'inherit'],
         }),
     );
 });
@@ -312,7 +312,7 @@ it('uses hide from options for each command', () => {
     expect(spawn).toHaveBeenCalledWith(
         'echo',
         expect.objectContaining({
-            stdio: 'pipe',
+            stdio: ['pipe', 'pipe', 'pipe'],
         }),
     );
     expect(spawn).toHaveBeenCalledWith(
@@ -333,7 +333,7 @@ it('hides output for commands even if raw option is on', () => {
     expect(spawn).toHaveBeenCalledWith(
         'echo',
         expect.objectContaining({
-            stdio: 'inherit',
+            stdio: ['inherit', 'inherit', 'inherit'],
         }),
     );
     expect(spawn).toHaveBeenCalledWith(

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -194,6 +194,7 @@ export function concurrently(
                     ...command,
                 },
                 getSpawnOpts({
+                    ipc: command.ipc,
                     stdio: hidden ? 'hidden' : command.raw ?? options.raw ? 'raw' : 'normal',
                     env: command.env,
                     cwd: command.cwd || options.cwd,
@@ -262,6 +263,7 @@ function mapToCommandInfo(command: ConcurrentlyCommandInput): CommandInfo {
         name: command.name || '',
         env: command.env || {},
         cwd: command.cwd || '',
+        ipc: command.ipc,
         ...(command.prefixColor
             ? {
                   prefixColor: command.prefixColor,

--- a/src/fixtures/fake-command.ts
+++ b/src/fixtures/fake-command.ts
@@ -30,6 +30,7 @@ export class FakeCommand extends Command {
 export const createFakeProcess = (pid: number): ChildProcess =>
     Object.assign(new EventEmitter(), {
         pid,
+        send: jest.fn(),
         stdin: new PassThrough(),
         stdout: new PassThrough(),
         stderr: new PassThrough(),

--- a/src/spawn.spec.ts
+++ b/src/spawn.spec.ts
@@ -28,15 +28,25 @@ describe('getSpawnOpts()', () => {
     });
 
     it('sets stdio to pipe when stdio mode is normal', () => {
-        expect(getSpawnOpts({ stdio: 'normal' }).stdio).toBe('pipe');
+        expect(getSpawnOpts({ stdio: 'normal' }).stdio).toBe(['pipe', 'pipe', 'pipe']);
     });
 
     it('sets stdio to inherit when stdio mode is raw', () => {
-        expect(getSpawnOpts({ stdio: 'raw' }).stdio).toBe('inherit');
+        expect(getSpawnOpts({ stdio: 'raw' }).stdio).toEqual(['inherit', 'inherit', 'inherit']);
     });
 
     it('sets stdio to ignore stdout + stderr when stdio mode is hidden', () => {
         expect(getSpawnOpts({ stdio: 'hidden' }).stdio).toEqual(['ignore', 'ignore', 'pipe']);
+    });
+
+    it('sets an ipc channel at the specified descriptor index', () => {
+        const opts = getSpawnOpts({ ipc: 3 });
+        expect(opts.stdio?.[3]).toBe('ipc');
+    });
+
+    it('throws if the ipc channel is <= 2', () => {
+        const fn = () => getSpawnOpts({ ipc: 0 });
+        expect(fn).toThrow();
     });
 
     it('merges FORCE_COLOR into env vars if color supported', () => {

--- a/src/spawn.spec.ts
+++ b/src/spawn.spec.ts
@@ -28,7 +28,7 @@ describe('getSpawnOpts()', () => {
     });
 
     it('sets stdio to pipe when stdio mode is normal', () => {
-        expect(getSpawnOpts({ stdio: 'normal' }).stdio).toBe(['pipe', 'pipe', 'pipe']);
+        expect(getSpawnOpts({ stdio: 'normal' }).stdio).toEqual(['pipe', 'pipe', 'pipe']);
     });
 
     it('sets stdio to inherit when stdio mode is raw', () => {


### PR DESCRIPTION
This PR implements basic inter-process communication (IPC), which is an API-only feature - not available through CLI.

`Command` has the following new fields/methods:
- `send`: to send messages
- `messages.incoming`: to listen for received messages
- `messages.outgoing`: to listen for sent messages

The caller must set the `ipc` property when calling `concurrently()`. It sets the number of the file descriptor on which to set up the IPC channel.

Example usage:

```js
const { commands } = concurrently([{ command: 'echo foo', ipc: 3 }]);
commands[0].send({ hello: 'world' })
commands[0].messages.incoming.subscribe(({ message }) => {
	console.log('command 0 sent this:', message);
});
```

With this PR I also realise that the README is no longer a good option for documentation.
We need to expand it into a website...
