### PR TITLE
Teardown commands

### DIFF
--- a/bin/concurrently.spec.ts
+++ b/bin/concurrently.spec.ts
@@ -438,6 +438,27 @@ describe('--handle-input', () => {
     });
 });
 
+describe('--teardown', () => {
+    it('runs teardown commands when input commands exit', async () => {
+        const lines = await run('--teardown "echo bye" "echo hey"').getLogLines();
+        expect(lines).toEqual([
+            expect.stringContaining('[0] hey'),
+            expect.stringContaining('[0] echo hey exited with code 0'),
+            expect.stringContaining('--> Running teardown command "echo bye"'),
+            expect.stringContaining('bye'),
+            expect.stringContaining('--> Teardown command "echo bye" exited with code 0'),
+        ]);
+    });
+
+    it('runs multiple teardown commands', async () => {
+        const lines = await run(
+            '--teardown "echo bye" --teardown "echo bye2" "echo hey"',
+        ).getLogLines();
+        expect(lines).toContain('bye');
+        expect(lines).toContain('bye2');
+    });
+});
+
 describe('--timings', () => {
     const defaultTimestampFormatRegex = /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}/;
     const processStartedMessageRegex = (index: number, command: string) => {

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -242,9 +242,7 @@ export function concurrently(
 
     const result = new CompletionListener({ successCondition: options.successCondition })
         .listen(commands, options.abortSignal)
-        .finally(() => {
-            handleResult.onFinishCallbacks.forEach((onFinish) => onFinish());
-        });
+        .finally(() => Promise.all(handleResult.onFinishCallbacks.map((onFinish) => onFinish())));
 
     return {
         result,

--- a/src/flow-control/flow-controller.ts
+++ b/src/flow-control/flow-controller.ts
@@ -7,5 +7,5 @@ import { Command } from '../command';
  * actually finish.
  */
 export interface FlowController {
-    handle(commands: Command[]): { commands: Command[]; onFinish?: () => void };
+    handle(commands: Command[]): { commands: Command[]; onFinish?: () => void | Promise<void> };
 }

--- a/src/flow-control/teardown.spec.ts
+++ b/src/flow-control/teardown.spec.ts
@@ -1,0 +1,90 @@
+import createMockInstance from 'jest-create-mock-instance';
+
+import { createFakeProcess, FakeCommand } from '../fixtures/fake-command';
+import { Logger } from '../logger';
+import { getSpawnOpts } from '../spawn';
+import { Teardown } from './teardown';
+
+let spawn: jest.Mock;
+let logger: Logger;
+const commands = [new FakeCommand()];
+const teardown = 'cowsay bye';
+
+beforeEach(() => {
+    logger = createMockInstance(Logger);
+    spawn = jest.fn(() => createFakeProcess(1));
+});
+
+const create = (teardown: string[]) =>
+    new Teardown({
+        spawn,
+        logger,
+        commands: teardown,
+    });
+
+it('returns commands unchanged', () => {
+    const { commands: actual } = create([]).handle(commands);
+    expect(actual).toBe(commands);
+});
+
+describe('onFinish callback', () => {
+    it('does not spawn nothing if there are no teardown commands', () => {
+        create([]).handle(commands).onFinish();
+        expect(spawn).not.toHaveBeenCalled();
+    });
+
+    it('runs teardown command', () => {
+        create([teardown]).handle(commands).onFinish();
+        expect(spawn).toHaveBeenCalledWith(teardown, getSpawnOpts({ stdio: 'raw' }));
+    });
+
+    it('waits for teardown command to close', async () => {
+        const child = createFakeProcess(1);
+        spawn.mockReturnValue(child);
+
+        const result = create([teardown]).handle(commands).onFinish();
+        child.emit('close', 1, null);
+        await expect(result).resolves.toBeUndefined();
+    });
+
+    it('rejects if teardown command errors', async () => {
+        const child = createFakeProcess(1);
+        spawn.mockReturnValue(child);
+
+        const result = create([teardown]).handle(commands).onFinish();
+        child.emit('error', 'fail');
+        await expect(result).rejects.toBeUndefined();
+    });
+
+    it('runs multiple teardown commands in sequence', async () => {
+        const child1 = createFakeProcess(1);
+        const child2 = createFakeProcess(2);
+        spawn.mockReturnValueOnce(child1).mockReturnValueOnce(child2);
+
+        const result = create(['foo', 'bar']).handle(commands).onFinish();
+
+        expect(spawn).toHaveBeenCalledTimes(1);
+        expect(spawn).toHaveBeenLastCalledWith('foo', getSpawnOpts({ stdio: 'raw' }));
+
+        child1.emit('close', 1, null);
+        await new Promise((resolve) => setTimeout(resolve));
+
+        expect(spawn).toHaveBeenCalledTimes(2);
+        expect(spawn).toHaveBeenLastCalledWith('bar', getSpawnOpts({ stdio: 'raw' }));
+
+        child2.emit('close', 0, null);
+        await expect(result).resolves.toBeUndefined();
+    });
+
+    it('stops running teardown commands on SIGINT', async () => {
+        const child = createFakeProcess(1);
+        spawn.mockReturnValue(child);
+
+        const result = create(['foo', 'bar']).handle(commands).onFinish();
+        child.emit('close', null, 'SIGINT');
+        await result;
+
+        expect(spawn).toHaveBeenCalledTimes(1);
+        expect(spawn).toHaveBeenLastCalledWith('foo', expect.anything());
+    });
+});

--- a/src/flow-control/teardown.ts
+++ b/src/flow-control/teardown.ts
@@ -12,7 +12,7 @@ export class Teardown implements FlowController {
 
     constructor({
         logger,
-        spawn = baseSpawn,
+        spawn,
         commands,
     }: {
         logger: Logger;
@@ -24,7 +24,7 @@ export class Teardown implements FlowController {
         commands: readonly string[];
     }) {
         this.logger = logger;
-        this.spawn = spawn;
+        this.spawn = spawn || baseSpawn;
         this.teardown = commands;
     }
 

--- a/src/flow-control/teardown.ts
+++ b/src/flow-control/teardown.ts
@@ -1,0 +1,73 @@
+import * as Rx from 'rxjs';
+
+import { Command, SpawnCommand } from '../command';
+import { Logger } from '../logger';
+import { getSpawnOpts, spawn as baseSpawn } from '../spawn';
+import { FlowController } from './flow-controller';
+
+export class Teardown implements FlowController {
+    private readonly logger: Logger;
+    private readonly spawn: SpawnCommand;
+    private readonly teardown: readonly string[];
+
+    constructor({
+        logger,
+        spawn = baseSpawn,
+        commands,
+    }: {
+        logger: Logger;
+        /**
+         * Which function to use to spawn commands.
+         * Defaults to the same used by the rest of concurrently.
+         */
+        spawn?: SpawnCommand;
+        commands: readonly string[];
+    }) {
+        this.logger = logger;
+        this.spawn = spawn;
+        this.teardown = commands;
+    }
+
+    handle(commands: Command[]): { commands: Command[]; onFinish: () => Promise<void> } {
+        const { logger, teardown, spawn } = this;
+        const onFinish = async () => {
+            if (!teardown.length) {
+                return;
+            }
+
+            for (const command of teardown) {
+                logger.logGlobalEvent(`Running teardown command "${command}"`);
+
+                const child = spawn(command, getSpawnOpts({ stdio: 'raw' }));
+                const error = Rx.fromEvent(child, 'error');
+                const close = Rx.fromEvent(child, 'close');
+
+                try {
+                    const [exitCode, signal] = await Promise.race([
+                        Rx.firstValueFrom(error).then((event) => {
+                            throw event;
+                        }),
+                        Rx.firstValueFrom(close).then(
+                            (event) => event as [number | null, NodeJS.Signals | null],
+                        ),
+                    ]);
+
+                    logger.logGlobalEvent(
+                        `Teardown command "${command}" exited with code ${exitCode ?? signal}`,
+                    );
+
+                    if (signal === 'SIGINT') {
+                        break;
+                    }
+                } catch (error) {
+                    const errorText = String(error instanceof Error ? error.stack || error : error);
+                    logger.logGlobalEvent(`Teardown command "${command}" errored:`);
+                    logger.logGlobalEvent(errorText);
+                    return Promise.reject();
+                }
+            }
+        };
+
+        return { commands, onFinish };
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { LogOutput } from './flow-control/log-output';
 import { LogTimings } from './flow-control/log-timings';
 import { LoggerPadding } from './flow-control/logger-padding';
 import { RestartDelay, RestartProcess } from './flow-control/restart-process';
+import { Teardown } from './flow-control/teardown';
 import { Logger } from './logger';
 
 export type ConcurrentlyOptions = Omit<BaseConcurrentlyOptions, 'abortSignal' | 'hide'> & {
@@ -92,6 +93,12 @@ export type ConcurrentlyOptions = Omit<BaseConcurrentlyOptions, 'abortSignal' | 
     timings?: boolean;
 
     /**
+     * Clean up command(s) to execute before exiting concurrently.
+     * These won't be prefixed and don't affect concurrently's exit code.
+     */
+    teardown?: readonly string[];
+
+    /**
      * List of additional arguments passed that will get replaced in each command.
      * If not defined, no argument replacing will happen.
      */
@@ -155,6 +162,7 @@ export function concurrently(
                 logger: options.timings ? logger : undefined,
                 timestampFormat: options.timestampFormat,
             }),
+            new Teardown({ logger, spawn: options.spawn, commands: options.teardown || [] }),
         ],
         prefixColors: options.prefixColors || [],
         additionalArguments: options.additionalArguments,


### PR DESCRIPTION
Introduces a `--teardown` flag to pass commands that execute when every input command exits.

```
$ concurrently --teardown "echo bye" "echo hey"
[0] hey
[0] echo hey exited with code 0
--> Running teardown command "echo bye"
bye
--> Teardown command "echo bye" exited with code 0
```

As you can see, teardown commands have no prefixing.

The flag can also be specified multiple times:

```
$ concurrently --teardown "echo bye" --teardown "echo real bye" "echo hey"
[0] hey
[0] echo hey exited with code 0
--> Running teardown command "echo bye"
bye
--> Teardown command "echo bye" exited with code 0
--> Running teardown command "echo real bye"
real bye
--> Teardown command "echo real bye" exited with code 0
```

Teardown commands also don't affect concurrently's exit code (unless it fails to spawn):

```
$ concurrently --teardown "exit 1" "echo hey"
[0] hey
[0] echo hey exited with code 0
--> Running teardown command "exit 1"
--> Teardown command "exit 1" exited with code 1

$ echo $?
0
```

Closes #472 