### PR TITLE
Don't set up more than 1 abort signal listener

### DIFF
--- a/src/completion-listener.ts
+++ b/src/completion-listener.ts
@@ -1,5 +1,5 @@
 import * as Rx from 'rxjs';
-import { delay, filter, map, switchMap, take } from 'rxjs/operators';
+import { delay, filter, map, share, switchMap, take } from 'rxjs/operators';
 
 import { CloseEvent, Command } from './command';
 
@@ -101,6 +101,9 @@ export class CompletionListener {
                 // without an immediate delay
                 delay(0, this.scheduler),
                 map(() => undefined),
+                // #502 - node might warn of too many active listeners on this object if it isn't shared,
+                // as each command subscribes to abort event over and over
+                share(),
             );
 
         const closeStreams = commands.map((command) =>


### PR DESCRIPTION
🤦 Rxjs' `fromEvent` creates a new listener on every subscription, but this is a bit hidden because the abort signal isn't subscribed to directly:

https://github.com/open-cli-tools/concurrently/blob/a7a5894e2daf9dd64059200cc1c53c756412b3cd/src/completion-listener.ts#L96-L109

Sounds like just sharing the underlying source observable is enough.

Fixes #502 