### PR TITLE
Add support for Deno shortcuts and wildcards 

### DIFF
--- a/docs/cli/shortcuts.md
+++ b/docs/cli/shortcuts.md
@@ -1,6 +1,6 @@
 # Command Shortcuts
 
-Package managers that execute scripts from a `package.json` file can be shortened when in concurrently.<br/>
+Package managers that execute scripts from a `package.json` or `deno.json` file can be shortened when in concurrently.<br/>
 The following are supported:
 
 | Syntax          | Expands to            |
@@ -10,6 +10,7 @@ The following are supported:
 | `yarn:<script>` | `yarn run <script>`   |
 | `bun:<script>`  | `bun run <script>`    |
 | `node:<script>` | `node --run <script>` |
+| `deno:<script>` | `deno task <script>`  |
 
 > [!NOTE]
 >

--- a/src/command-parser/expand-npm-shortcut.spec.ts
+++ b/src/command-parser/expand-npm-shortcut.spec.ts
@@ -8,33 +8,34 @@ const createCommandInfo = (command: string, name = ''): CommandInfo => ({
     command,
 });
 
-it('returns same command if no npm: prefix is present', () => {
+it('returns same command if no prefix is present', () => {
     const commandInfo = createCommandInfo('echo foo');
     expect(parser.parse(commandInfo)).toBe(commandInfo);
 });
 
 describe.each([
-    ['npm', 'run'],
-    ['yarn', 'run'],
-    ['pnpm', 'run'],
-    ['bun', 'run'],
-    ['node', '--run'],
-])(`with %s: prefix`, (npmCmd, runCmd) => {
-    it(`expands to "${npmCmd} ${runCmd} <script> <args>"`, () => {
-        const commandInfo = createCommandInfo(`${npmCmd}:foo -- bar`, 'echo');
+    ['npm', 'npm run'],
+    ['yarn', 'yarn run'],
+    ['pnpm', 'pnpm run'],
+    ['bun', 'bun run'],
+    ['node', 'node --run'],
+    ['deno', 'deno task'],
+])(`with '%s:' prefix`, (prefix, command) => {
+    it(`expands to "${command} <script> <args>"`, () => {
+        const commandInfo = createCommandInfo(`${prefix}:foo -- bar`, 'echo');
         expect(parser.parse(commandInfo)).toEqual({
             ...commandInfo,
             name: 'echo',
-            command: `${npmCmd} ${runCmd} foo -- bar`,
+            command: `${command} foo -- bar`,
         });
     });
 
     it('sets name to script name if none', () => {
-        const commandInfo = createCommandInfo(`${npmCmd}:foo -- bar`);
+        const commandInfo = createCommandInfo(`${prefix}:foo -- bar`);
         expect(parser.parse(commandInfo)).toEqual({
             ...commandInfo,
             name: 'foo',
-            command: `${npmCmd} ${runCmd} foo -- bar`,
+            command: `${command} foo -- bar`,
         });
     });
 });

--- a/src/command-parser/expand-npm-wildcard.spec.ts
+++ b/src/command-parser/expand-npm-wildcard.spec.ts
@@ -4,7 +4,8 @@ import { CommandInfo } from '../command';
 import { ExpandNpmWildcard } from './expand-npm-wildcard';
 
 let parser: ExpandNpmWildcard;
-let readPkg: jest.Mock;
+let readPackage: jest.Mock;
+let readDeno: jest.Mock;
 
 const createCommandInfo = (command: string): CommandInfo => ({
     command,
@@ -12,15 +13,43 @@ const createCommandInfo = (command: string): CommandInfo => ({
 });
 
 beforeEach(() => {
-    readPkg = jest.fn();
-    parser = new ExpandNpmWildcard(readPkg);
+    readDeno = jest.fn();
+    readPackage = jest.fn();
+    parser = new ExpandNpmWildcard(readDeno, readPackage);
 });
 
 afterEach(() => {
     jest.restoreAllMocks();
 });
 
-describe('ExpandNpmWildcard#readPackage', () => {
+describe('ExpandWildcard#readDeno', () => {
+    it('can read deno', () => {
+        const expectedDeno = {
+            name: 'deno',
+            version: '1.14.0',
+        };
+        jest.spyOn(fs, 'readFileSync').mockImplementation((path) => {
+            if (path === 'deno.json') {
+                return JSON.stringify(expectedDeno);
+            }
+            return '';
+        });
+
+        const actualReadDeno = ExpandNpmWildcard.readDeno();
+        expect(actualReadDeno).toEqual(expectedDeno);
+    });
+
+    it('can handle errors reading deno', () => {
+        jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
+            throw new Error('Error reading deno');
+        });
+
+        expect(() => ExpandNpmWildcard.readDeno()).not.toThrow();
+        expect(ExpandNpmWildcard.readDeno()).toEqual({});
+    });
+});
+
+describe('ExpandWildcard#readPackage', () => {
     it('can read package', () => {
         const expectedPackage = {
             name: 'concurrently',
@@ -50,46 +79,157 @@ describe('ExpandNpmWildcard#readPackage', () => {
 it('returns same command if not an npm run command', () => {
     const commandInfo = createCommandInfo('npm test');
 
-    expect(readPkg).not.toHaveBeenCalled();
+    expect(readDeno).not.toHaveBeenCalled();
+    expect(readPackage).not.toHaveBeenCalled();
+    expect(parser.parse(commandInfo)).toBe(commandInfo);
+});
+
+it('returns same command if not a deno task command', () => {
+    const commandInfo = createCommandInfo('deno run');
+
+    expect(readDeno).not.toHaveBeenCalled();
+    expect(readPackage).not.toHaveBeenCalled();
     expect(parser.parse(commandInfo)).toBe(commandInfo);
 });
 
 it('returns same command if no wildcard present', () => {
     const commandInfo = createCommandInfo('npm run foo bar');
 
-    expect(readPkg).not.toHaveBeenCalled();
+    expect(readPackage).not.toHaveBeenCalled();
     expect(parser.parse(commandInfo)).toBe(commandInfo);
 });
 
 it('expands to nothing if no scripts exist in package.json', () => {
-    readPkg.mockReturnValue({});
+    readPackage.mockReturnValue({});
 
     expect(parser.parse(createCommandInfo('npm run foo-*-baz qux'))).toEqual([]);
 });
 
-describe.each([
-    ['npm', 'run'],
-    ['yarn', 'run'],
-    ['pnpm', 'run'],
-    ['bun', 'run'],
-    ['node', '--run'],
-])(`with a %s: prefix`, (npmCmd, runCmd) => {
+it('expands to nothing if no tasks exist in deno.json and no scripts exist in package.json', () => {
+    readDeno.mockReturnValue({});
+    readPackage.mockReturnValue({});
+
+    expect(parser.parse(createCommandInfo('deno task foo-*-baz qux'))).toEqual([]);
+});
+
+describe.each(['npm run', 'yarn run', 'pnpm run', 'bun run', 'node --run'])(
+    `with a '%s' prefix`,
+    (command) => {
+        it('expands to all scripts matching pattern', () => {
+            readPackage.mockReturnValue({
+                scripts: {
+                    'foo-bar-baz': '',
+                    'foo--baz': '',
+                },
+            });
+
+            expect(parser.parse(createCommandInfo(`${command} foo-*-baz qux`))).toEqual([
+                { name: 'bar', command: `${command} foo-bar-baz qux` },
+                { name: '', command: `${command} foo--baz qux` },
+            ]);
+        });
+
+        it('uses wildcard match of script as command name', () => {
+            readPackage.mockReturnValue({
+                scripts: {
+                    'watch-js': '',
+                    'watch-css': '',
+                },
+            });
+
+            expect(
+                parser.parse({
+                    name: '',
+                    command: `${command} watch-*`,
+                }),
+            ).toEqual([
+                { name: 'js', command: `${command} watch-js` },
+                { name: 'css', command: `${command} watch-css` },
+            ]);
+        });
+
+        it('uses existing command name as prefix to the wildcard match', () => {
+            readPackage.mockReturnValue({
+                scripts: {
+                    'watch-js': '',
+                    'watch-css': '',
+                },
+            });
+
+            expect(
+                parser.parse({
+                    name: 'w:',
+                    command: `${command} watch-*`,
+                }),
+            ).toEqual([
+                { name: 'w:js', command: `${command} watch-js` },
+                { name: 'w:css', command: `${command} watch-css` },
+            ]);
+        });
+
+        it('allows negation', () => {
+            readPackage.mockReturnValue({
+                scripts: {
+                    'lint:js': '',
+                    'lint:ts': '',
+                    'lint:fix:js': '',
+                    'lint:fix:ts': '',
+                },
+            });
+
+            expect(parser.parse(createCommandInfo(`${command} lint:*(!fix)`))).toEqual([
+                { name: 'js', command: `${command} lint:js` },
+                { name: 'ts', command: `${command} lint:ts` },
+            ]);
+        });
+
+        it('caches scripts upon calls', () => {
+            readPackage.mockReturnValue({});
+
+            parser.parse(createCommandInfo(`${command} foo-*-baz qux`));
+            parser.parse(createCommandInfo(`${command} foo-*-baz qux`));
+
+            expect(readPackage).toHaveBeenCalledTimes(1);
+        });
+
+        it("doesn't read deno.json", () => {
+            readPackage.mockReturnValue({});
+
+            parser.parse(createCommandInfo(`${command} foo-*-baz qux`));
+
+            expect(readDeno).not.toHaveBeenCalled();
+        });
+    },
+);
+
+describe(`with a 'deno task' prefix`, () => {
     it('expands to all scripts matching pattern', () => {
-        readPkg.mockReturnValue({
-            scripts: {
+        readDeno.mockReturnValue({
+            tasks: {
                 'foo-bar-baz': '',
                 'foo--baz': '',
             },
         });
+        readPackage.mockReturnValue({
+            scripts: {
+                'foo-foo-baz': '',
+            },
+        });
 
-        expect(parser.parse(createCommandInfo(`${npmCmd} ${runCmd} foo-*-baz qux`))).toEqual([
-            { name: 'bar', command: `${npmCmd} ${runCmd} foo-bar-baz qux` },
-            { name: '', command: `${npmCmd} ${runCmd} foo--baz qux` },
+        expect(parser.parse(createCommandInfo(`deno task foo-*-baz qux`))).toEqual([
+            { name: 'bar', command: `deno task foo-bar-baz qux` },
+            { name: '', command: `deno task foo--baz qux` },
+            { name: 'foo', command: `deno task foo-foo-baz qux` },
         ]);
     });
 
     it('uses wildcard match of script as command name', () => {
-        readPkg.mockReturnValue({
+        readDeno.mockReturnValue({
+            tasks: {
+                'watch-sass': '',
+            },
+        });
+        readPackage.mockReturnValue({
             scripts: {
                 'watch-js': '',
                 'watch-css': '',
@@ -99,16 +239,22 @@ describe.each([
         expect(
             parser.parse({
                 name: '',
-                command: `${npmCmd} ${runCmd} watch-*`,
+                command: `deno task watch-*`,
             }),
         ).toEqual([
-            { name: 'js', command: `${npmCmd} ${runCmd} watch-js` },
-            { name: 'css', command: `${npmCmd} ${runCmd} watch-css` },
+            { name: 'sass', command: `deno task watch-sass` },
+            { name: 'js', command: `deno task watch-js` },
+            { name: 'css', command: `deno task watch-css` },
         ]);
     });
 
     it('uses existing command name as prefix to the wildcard match', () => {
-        readPkg.mockReturnValue({
+        readDeno.mockReturnValue({
+            tasks: {
+                'watch-sass': '',
+            },
+        });
+        readPackage.mockReturnValue({
             scripts: {
                 'watch-js': '',
                 'watch-css': '',
@@ -118,16 +264,23 @@ describe.each([
         expect(
             parser.parse({
                 name: 'w:',
-                command: `${npmCmd} ${runCmd} watch-*`,
+                command: `deno task watch-*`,
             }),
         ).toEqual([
-            { name: 'w:js', command: `${npmCmd} ${runCmd} watch-js` },
-            { name: 'w:css', command: `${npmCmd} ${runCmd} watch-css` },
+            { name: 'w:sass', command: `deno task watch-sass` },
+            { name: 'w:js', command: `deno task watch-js` },
+            { name: 'w:css', command: `deno task watch-css` },
         ]);
     });
 
     it('allows negation', () => {
-        readPkg.mockReturnValue({
+        readDeno.mockReturnValue({
+            tasks: {
+                'lint:sass': '',
+                'lint:fix:sass': '',
+            },
+        });
+        readPackage.mockReturnValue({
             scripts: {
                 'lint:js': '',
                 'lint:ts': '',
@@ -136,17 +289,21 @@ describe.each([
             },
         });
 
-        expect(parser.parse(createCommandInfo(`${npmCmd} ${runCmd} lint:*(!fix)`))).toEqual([
-            { name: 'js', command: `${npmCmd} ${runCmd} lint:js` },
-            { name: 'ts', command: `${npmCmd} ${runCmd} lint:ts` },
+        expect(parser.parse(createCommandInfo(`deno task lint:*(!fix)`))).toEqual([
+            { name: 'sass', command: `deno task lint:sass` },
+            { name: 'js', command: `deno task lint:js` },
+            { name: 'ts', command: `deno task lint:ts` },
         ]);
     });
 
     it('caches scripts upon calls', () => {
-        readPkg.mockReturnValue({});
-        parser.parse(createCommandInfo(`${npmCmd} run foo-*-baz qux`));
-        parser.parse(createCommandInfo(`${npmCmd} run foo-*-baz qux`));
+        readDeno.mockReturnValue({});
+        readPackage.mockReturnValue({});
 
-        expect(readPkg).toHaveBeenCalledTimes(1);
+        parser.parse(createCommandInfo(`deno task foo-*-baz qux`));
+        parser.parse(createCommandInfo(`deno task foo-*-baz qux`));
+
+        expect(readDeno).toHaveBeenCalledTimes(1);
+        expect(readPackage).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/command-parser/expand-shortcut.spec.ts
+++ b/src/command-parser/expand-shortcut.spec.ts
@@ -1,7 +1,7 @@
 import { CommandInfo } from '../command';
-import { ExpandNpmShortcut } from './expand-npm-shortcut';
+import { ExpandShortcut } from './expand-shortcut';
 
-const parser = new ExpandNpmShortcut();
+const parser = new ExpandShortcut();
 
 const createCommandInfo = (command: string, name = ''): CommandInfo => ({
     name,

--- a/src/command-parser/expand-shortcut.ts
+++ b/src/command-parser/expand-shortcut.ts
@@ -13,7 +13,7 @@ import { CommandParser } from './command-parser';
  * | `node:<script>` | `node --run <script>` |
  * | `deno:<script>` | `deno task <script>`  |
  */
-export class ExpandNpmShortcut implements CommandParser {
+export class ExpandShortcut implements CommandParser {
     parse(commandInfo: CommandInfo) {
         const [, prefix, script, args] =
             /^(npm|yarn|pnpm|bun|node|deno):(\S+)(.*)/.exec(commandInfo.command) || [];

--- a/src/command-parser/expand-wildcard.spec.ts
+++ b/src/command-parser/expand-wildcard.spec.ts
@@ -1,9 +1,9 @@
 import fs from 'fs';
 
 import { CommandInfo } from '../command';
-import { ExpandNpmWildcard } from './expand-npm-wildcard';
+import { ExpandWildcard } from './expand-wildcard';
 
-let parser: ExpandNpmWildcard;
+let parser: ExpandWildcard;
 let readPackage: jest.Mock;
 let readDeno: jest.Mock;
 
@@ -15,7 +15,7 @@ const createCommandInfo = (command: string): CommandInfo => ({
 beforeEach(() => {
     readDeno = jest.fn();
     readPackage = jest.fn();
-    parser = new ExpandNpmWildcard(readDeno, readPackage);
+    parser = new ExpandWildcard(readDeno, readPackage);
 });
 
 afterEach(() => {
@@ -35,7 +35,7 @@ describe('ExpandWildcard#readDeno', () => {
             return '';
         });
 
-        const actualReadDeno = ExpandNpmWildcard.readDeno();
+        const actualReadDeno = ExpandWildcard.readDeno();
         expect(actualReadDeno).toEqual(expectedDeno);
     });
 
@@ -44,8 +44,8 @@ describe('ExpandWildcard#readDeno', () => {
             throw new Error('Error reading deno');
         });
 
-        expect(() => ExpandNpmWildcard.readDeno()).not.toThrow();
-        expect(ExpandNpmWildcard.readDeno()).toEqual({});
+        expect(() => ExpandWildcard.readDeno()).not.toThrow();
+        expect(ExpandWildcard.readDeno()).toEqual({});
     });
 });
 
@@ -62,7 +62,7 @@ describe('ExpandWildcard#readPackage', () => {
             return '';
         });
 
-        const actualReadPackage = ExpandNpmWildcard.readPackage();
+        const actualReadPackage = ExpandWildcard.readPackage();
         expect(actualReadPackage).toEqual(expectedPackage);
     });
 
@@ -71,8 +71,8 @@ describe('ExpandWildcard#readPackage', () => {
             throw new Error('Error reading package');
         });
 
-        expect(() => ExpandNpmWildcard.readPackage()).not.toThrow();
-        expect(ExpandNpmWildcard.readPackage()).toEqual({});
+        expect(() => ExpandWildcard.readPackage()).not.toThrow();
+        expect(ExpandWildcard.readPackage()).toEqual({});
     });
 });
 

--- a/src/command-parser/expand-wildcard.ts
+++ b/src/command-parser/expand-wildcard.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import { CommandInfo } from '../command';
 import { CommandParser } from './command-parser';
 
+// Matches a negative filter surrounded by '(!' and ')'.
 const OMISSION = /\(!([^)]+)\)/;
 
 /**

--- a/src/command-parser/expand-wildcard.ts
+++ b/src/command-parser/expand-wildcard.ts
@@ -11,7 +11,7 @@ const OMISSION = /\(!([^)]+)\)/;
  * commands and replaces them with all matching scripts in the `package.json`
  * and `deno.json` files of the current directory.
  */
-export class ExpandNpmWildcard implements CommandParser {
+export class ExpandWildcard implements CommandParser {
     static readDeno() {
         try {
             const json = fs.readFileSync('deno.json', { encoding: 'utf-8' });
@@ -34,8 +34,8 @@ export class ExpandNpmWildcard implements CommandParser {
     private denoTasks?: string[];
 
     constructor(
-        private readonly readDeno = ExpandNpmWildcard.readDeno,
-        private readonly readPackage = ExpandNpmWildcard.readPackage,
+        private readonly readDeno = ExpandWildcard.readDeno,
+        private readonly readPackage = ExpandWildcard.readPackage,
     ) {}
 
     private relevantScripts(command: string): string[] {

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -14,8 +14,8 @@ import {
 } from './command';
 import { CommandParser } from './command-parser/command-parser';
 import { ExpandArguments } from './command-parser/expand-arguments';
-import { ExpandNpmShortcut } from './command-parser/expand-npm-shortcut';
-import { ExpandNpmWildcard } from './command-parser/expand-npm-wildcard';
+import { ExpandShortcut } from './command-parser/expand-shortcut';
+import { ExpandWildcard } from './command-parser/expand-wildcard';
 import { StripQuotes } from './command-parser/strip-quotes';
 import { CompletionListener, SuccessCondition } from './completion-listener';
 import { FlowController } from './flow-control/flow-controller';
@@ -175,8 +175,8 @@ export function concurrently(
 
     const commandParsers: CommandParser[] = [
         new StripQuotes(),
-        new ExpandNpmShortcut(),
-        new ExpandNpmWildcard(),
+        new ExpandShortcut(),
+        new ExpandWildcard(),
     ];
 
     if (options.additionalArguments) {


### PR DESCRIPTION
With the release of Deno 2, I figured I'd have a look if the amazing shortcut and wildcard features of this tool supported it. Sadly, they didn't. Luckily, adding it wasn't too difficult. One thing to note is that Deno uses its own `deno.json` file with what it calls 'tasks', but can also fall back on Node's `scripts` directive in the `package.json`.

For a cleaner reviewing process, I recommend looking at the individual commits, as it doesn't quite seem to understand I renamed some files.