### PR TITLE
fix: support Deno's JSON with comments configuration

### DIFF
--- a/docs/cli/shortcuts.md
+++ b/docs/cli/shortcuts.md
@@ -1,6 +1,6 @@
 # Command Shortcuts
 
-Package managers that execute scripts from a `package.json` or `deno.json` file can be shortened when in concurrently.<br/>
+Package managers that execute scripts from a `package.json` or `deno.(json|jsonc)` file can be shortened when in concurrently.<br/>
 The following are supported:
 
 | Syntax          | Expands to            |

--- a/src/command-parser/expand-wildcard.ts
+++ b/src/command-parser/expand-wildcard.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import _ from 'lodash';
 
 import { CommandInfo } from '../command';
+import JSONC from '../jsonc';
 import { CommandParser } from './command-parser';
 
 // Matches a negative filter surrounded by '(!' and ')'.
@@ -9,14 +10,21 @@ const OMISSION = /\(!([^)]+)\)/;
 
 /**
  * Finds wildcards in 'npm/yarn/pnpm/bun run', 'node --run' and 'deno task'
- * commands and replaces them with all matching scripts in the `package.json`
- * and `deno.json` files of the current directory.
+ * commands and replaces them with all matching scripts in the NodeJS and Deno
+ * configuration files of the current directory.
  */
 export class ExpandWildcard implements CommandParser {
     static readDeno() {
         try {
-            const json = fs.readFileSync('deno.json', { encoding: 'utf-8' });
-            return JSON.parse(json);
+            let json: string = '{}';
+
+            if (fs.existsSync('deno.json')) {
+                json = fs.readFileSync('deno.json', { encoding: 'utf-8' });
+            } else if (fs.existsSync('deno.jsonc')) {
+                json = fs.readFileSync('deno.jsonc', { encoding: 'utf-8' });
+            }
+
+            return JSONC.parse(json);
         } catch (e) {
             return {};
         }

--- a/src/jsonc.spec.ts
+++ b/src/jsonc.spec.ts
@@ -1,0 +1,84 @@
+/*
+ORIGINAL https://www.npmjs.com/package/tiny-jsonc
+BY Fabio Spampinato
+MIT license
+
+Copied due to the dependency not being compatible with CommonJS
+*/
+
+import JSONC from './jsonc';
+
+const Fixtures = {
+    errors: {
+        comment: '// asd',
+        empty: '',
+        prefix: 'invalid 123',
+        suffix: '123 invalid',
+        multiLineString: `
+        {
+            "foo": "/*
+            */"
+        }
+        `,
+    },
+    parse: {
+        input: `
+        // Example // Yes
+        /* EXAMPLE */ /* YES */
+        {
+            "one": {},
+            "two" :{},
+            "three": {
+                "one": null,
+                "two" :true,
+                "three": false,
+                "four": "asd\\n\\u0022\\"",  
+                "five": -123.123e10,
+                "six": [ 123, true, [],],
+            },
+        }
+        // Example // Yes
+        /* EXAMPLE */ /* YES */
+        `,
+        output: {
+            one: {},
+            two: {},
+            three: {
+                one: null,
+                two: true,
+                three: false,
+                four: 'asd\n\u0022"',
+                five: -123.123e10,
+                six: [123, true, []],
+            },
+        },
+    },
+};
+
+describe('Tiny JSONC', () => {
+    it('supports strings with comments and trailing commas', () => {
+        const { input, output } = Fixtures.parse;
+
+        expect(JSONC.parse(input)).toEqual(output);
+    });
+
+    it('throws on invalid input', () => {
+        const { prefix, suffix } = Fixtures.errors;
+
+        expect(() => JSONC.parse(prefix)).toThrow(SyntaxError);
+        expect(() => JSONC.parse(suffix)).toThrow(SyntaxError);
+    });
+
+    it('throws on insufficient input', () => {
+        const { comment, empty } = Fixtures.errors;
+
+        expect(() => JSONC.parse(comment)).toThrow(SyntaxError);
+        expect(() => JSONC.parse(empty)).toThrow(SyntaxError);
+    });
+
+    it('throws on multi-line strings', () => {
+        const { multiLineString } = Fixtures.errors;
+
+        expect(() => JSONC.parse(multiLineString)).toThrow(SyntaxError);
+    });
+});

--- a/src/jsonc.ts
+++ b/src/jsonc.ts
@@ -1,0 +1,32 @@
+/*
+ORIGINAL https://www.npmjs.com/package/tiny-jsonc
+BY Fabio Spampinato
+MIT license
+
+Copied due to the dependency not being compatible with CommonJS
+*/
+
+/* HELPERS */
+const stringOrCommentRe = /("(?:\\?[^])*?")|(\/\/.*)|(\/\*[^]*?\*\/)/g;
+const stringOrTrailingCommaRe = /("(?:\\?[^])*?")|(,\s*)(?=]|})/g;
+
+/* MAIN */
+const JSONC = {
+    parse: (text: string) => {
+        text = String(text); // To be extra safe
+
+        try {
+            // Fast path for valid JSON
+            return JSON.parse(text);
+        } catch {
+            // Slow path for JSONC and invalid inputs
+            return JSON.parse(
+                text.replace(stringOrCommentRe, '$1').replace(stringOrTrailingCommaRe, '$1'),
+            );
+        }
+    },
+    stringify: JSON.stringify,
+};
+
+/* EXPORT */
+export default JSONC;


### PR DESCRIPTION
Deno supports JSONC (JSON with comments) as project configuration, in both `deno.json` and `deno.jsonc`.

Had to manually copy the dependency because it wouldn't work in a CommonJS project. Argument in favour of #482.