### PR TITLE
fix: don't throw when there are no commands

### DIFF
--- a/src/completion-listener.spec.ts
+++ b/src/completion-listener.spec.ts
@@ -32,6 +32,11 @@ const emitFakeCloseEvent = (command: FakeCommand, event?: Partial<CloseEvent>) =
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe('listen', () => {
+    it('resolves when there are no commands', async () => {
+        const result = createController().listen([]);
+        await expect(result).resolves.toHaveLength(0);
+    });
+
     it('completes only when commands emit a close event, returns close event', async () => {
         const abortCtrl = new AbortController();
         const result = createController('all').listen(commands, abortCtrl.signal);

--- a/src/completion-listener.ts
+++ b/src/completion-listener.ts
@@ -93,6 +93,10 @@ export class CompletionListener {
      *          Commands that didn't spawn are filtered out.
      */
     listen(commands: Command[], abortSignal?: AbortSignal): Promise<CloseEvent[]> {
+        if (!commands.length) {
+            return Promise.resolve([]);
+        }
+
         const abort =
             abortSignal &&
             Rx.fromEvent(abortSignal, 'abort', { once: true }).pipe(
@@ -112,6 +116,7 @@ export class CompletionListener {
                   Rx.race(command.close, abort.pipe(filter(() => command.state === 'stopped')))
                 : command.close,
         );
+
         return Rx.lastValueFrom(
             Rx.combineLatest(closeStreams).pipe(
                 filter(() => commands.every((command) => command.state !== 'started')),


### PR DESCRIPTION
There's a guard against no inputs in https://github.com/open-cli-tools/concurrently/blob/4ffe63bc4af51f355fe312fe11f2f3519e893bf7/src/concurrently.ts#L170

However, there can still a situation where are no commands to run if one of the inputs is a wildcard that doesn't expand to anything.
This has been detected as the cause of #527, though it's not a fix for it. `CompletionListener` should simply assume that no commands = success.