### PR TITLE
docs: nicer quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The tool is written in Node.js, but you can use it to run **any** commands.
 Remember to surround separate commands with quotes:
 
 ```bash
-concurrently "command1 arg" "command2 arg"
+concurrently 'command1 arg' 'command2 arg'
 ```
 
 Otherwise **concurrently** would try to run 4 separate commands:
@@ -70,7 +70,7 @@ Otherwise **concurrently** would try to run 4 separate commands:
 In package.json, escape quotes:
 
 ```bash
-"start": "concurrently \"command1 arg\" \"command2 arg\""
+"start": "concurrently 'command1 arg' 'command2 arg'"
 ```
 
 You can always check concurrently's flag list by running `concurrently --help`.

--- a/docs/cli/input-handling.md
+++ b/docs/cli/input-handling.md
@@ -4,7 +4,7 @@ By default, concurrently doesn't send input to any commands it spawns.<br/>
 In the below example, typing `rs` to manually restart [nodemon](https://nodemon.io/) does nothing:
 
 ```bash
-$ concurrently "nodemon" "npm run watch-js"
+$ concurrently 'nodemon' 'npm run watch-js'
 rs
 ```
 
@@ -12,7 +12,7 @@ To turn on input handling, it's necessary to set the `--handle-input`/`-i` flag.
 This will send `rs` to the first command:
 
 ```bash
-$ concurrently --handle-input "nodemon" "npm run watch-js"
+$ concurrently --handle-input 'nodemon' 'npm run watch-js'
 rs
 ```
 
@@ -20,14 +20,14 @@ To send input to a different command instead, it's possible to prefix the input 
 For example, the below sends `rs` to the second command:
 
 ```bash
-$ concurrently --handle-input "npm run watch-js" "nodemon"
+$ concurrently --handle-input 'npm run watch-js' 'nodemon'
 1:rs
 ```
 
 If the command has a name, it's also possible to target it using that command's name:
 
 ```bash
-$ concurrently --handle-input --names js,server "npm run watch-js" "nodemon"
+$ concurrently --handle-input --names js,server 'npm run watch-js' 'nodemon'
 server:rs
 ```
 
@@ -35,6 +35,6 @@ It's also possible to change the default command that receives input.<br/>
 To do this, set the `--default-input-target` flag to a command's index or name.
 
 ```bash
-$ concurrently --handle-input --default-input-target 1 "npm run watch-js" "nodemon"
+$ concurrently --handle-input --default-input-target 1 'npm run watch-js' 'nodemon'
 rs
 ```

--- a/docs/cli/output-control.md
+++ b/docs/cli/output-control.md
@@ -7,7 +7,7 @@ concurrently offers a few ways to control a command's output.
 A command's outputs (and all its events) can be hidden by using the `--hide` flag.
 
 ```bash
-$ concurrently --hide 0 "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently --hide 0 'echo Hello there' 'echo General Kenobi!'
 [1] General Kenobi!
 [1] echo 'General Kenobi!' exited with code 0
 ```
@@ -18,7 +18,7 @@ It might be useful at times to make sure that the commands outputs are grouped t
 This can be done with the `--group` flag.
 
 ```bash
-$ concurrently --group "echo Hello there && sleep 2 && echo 'General Kenobi!'" "echo hi Star Wars fans"
+$ concurrently --group 'echo Hello there && sleep 2 && echo General Kenobi!' 'echo hi Star Wars fans'
 [0] Hello there
 [0] General Kenobi!
 [0] echo Hello there && sleep 2 && echo 'General Kenobi!' exited with code 0
@@ -31,5 +31,5 @@ $ concurrently --group "echo Hello there && sleep 2 && echo 'General Kenobi!'" "
 When piping concurrently's outputs to another command or file, you might want to force it to not use colors, as these can break the other command's parsing, or reduce the legibility of the output in non-terminal environments.
 
 ```bash
-$ concurrently -c red,blue --no-color "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently -c red,blue --no-color 'echo Hello there' 'echo General Kenobi!'
 ```

--- a/docs/cli/prefixing.md
+++ b/docs/cli/prefixing.md
@@ -5,7 +5,7 @@
 concurrently will by default prefix each command's outputs with a zero-based index, wrapped in square brackets:
 
 ```bash
-$ concurrently "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently 'echo Hello there' "echo 'General Kenobi!'"
 [0] Hello there
 [1] General Kenobi!
 [0] echo Hello there exited with code 0
@@ -15,7 +15,7 @@ $ concurrently "echo Hello there" "echo 'General Kenobi!'"
 If you've given the commands names, they are used instead:
 
 ```bash
-$ concurrently --names one,two "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently --names one,two 'echo Hello there' "echo 'General Kenobi!'"
 [one] Hello there
 [two] General Kenobi!
 [one] echo Hello there exited with code 0
@@ -36,7 +36,7 @@ There are other prefix styles available too:
 Any of these can be used by setting the `--prefix`/`-p` flag. For example:
 
 ```bash
-$ concurrently --prefix pid "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently --prefix pid 'echo Hello there' 'echo General Kenobi!'
 [2222] Hello there
 [2223] General Kenobi!
 [2222] echo Hello there exited with code 0
@@ -47,7 +47,7 @@ It's also possible to have a prefix based on a template. Any of the styles liste
 Doing so will also remove the square brackets:
 
 ```bash
-$ concurrently --prefix "{index}-{pid}" "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently --prefix '{index}-{pid}' 'echo Hello there' 'echo General Kenobi!'
 0-2222 Hello there
 1-2223 General Kenobi!
 0-2222 echo Hello there exited with code 0
@@ -62,7 +62,7 @@ This can be changed by using the `--prefix-colors`/`-c` flag, which takes a comm
 The available values are color names (e.g. `green`, `magenta`, `gray`, etc), a hex value (such as `#23de43`), or `auto`, to automatically select a color.
 
 ```bash
-$ concurrently -c red,blue "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently -c red,blue 'echo Hello there' 'echo General Kenobi!'
 ```
 
 <details>
@@ -82,7 +82,7 @@ $ concurrently -c red,blue "echo Hello there" "echo 'General Kenobi!'"
 Colors can take modifiers too. Several can be applied at once by prepending `.<modifier 1>.<modifier 2>` and so on.
 
 ```bash
-$ concurrently -c red,bold.blue.dim "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently -c red,bold.blue.dim 'echo Hello there' 'echo General Kenobi!'
 ```
 
 <details>
@@ -101,7 +101,7 @@ $ concurrently -c red,bold.blue.dim "echo Hello there" "echo 'General Kenobi!'"
 A background color can be set in a similary fashion.
 
 ```bash
-$ concurrently -c bgGray,red.bgBlack "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently -c bgGray,red.bgBlack 'echo Hello there' 'echo General Kenobi!'
 ```
 
 <details>
@@ -124,7 +124,7 @@ When using the `command` prefix style, it's possible that it'll be too long.<br/
 It can be limited by setting the `--prefix-length`/`-l` flag:
 
 ```bash
-$ concurrently -p command -l 10 "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently -p command -l 10 'echo Hello there' 'echo General Kenobi!'
 [echo..here] Hello there
 [echo..bi!'] General Kenobi!
 [echo..here] echo Hello there exited with code 0
@@ -135,7 +135,7 @@ It's also possible that some prefixes are too short, and you want all of them to
 This can be done by setting the `--pad-prefix` flag:
 
 ```bash
-$ concurrently -n foo,barbaz --pad-prefix "echo Hello there" "echo 'General Kenobi!'"
+$ concurrently -n foo,barbaz --pad-prefix 'echo Hello there' 'echo General Kenobi!'
 [foo   ] Hello there
 [foo   ] echo Hello there exited with code 0
 [barbaz] General Kenobi!

--- a/docs/cli/restarting.md
+++ b/docs/cli/restarting.md
@@ -4,7 +4,7 @@ Sometimes it's useful to have commands that exited with a non-zero status to res
 concurrently lets you configure how many times you wish for such a command to restart through the `--restart-tries` flag:
 
 ```bash
-$ concurrently --restart-tries 2 "exit 1"
+$ concurrently --restart-tries 2 'exit 1'
 [0] exit 1 exited with code 1
 [0] exit 1 restarted
 [0] exit 1 exited with code 1
@@ -16,7 +16,7 @@ Sometimes, it might be interesting to have commands wait before restarting.<br/>
 To do this, simply set `--restart-after` to a the number of milliseconds you'd like to delay restarting.
 
 ```bash
-$ concurrently -p time --restart-tries 1 --restart-after 3000 "exit 1"
+$ concurrently -p time --restart-tries 1 --restart-after 3000 'exit 1'
 [2024-09-01 23:43:55.871] exit 1 exited with code 1
 [2024-09-01 23:43:58.874] exit 1 restarted
 [2024-09-01 23:43:58.891] exit 1 exited with code 1
@@ -26,7 +26,7 @@ If a command is not having success spawning, you might want to instead apply an 
 Set `--restart-after exponential` to have commands respawn with a `2^N` seconds delay.
 
 ```bash
-$ concurrently -p time --restart-tries 3 --restart-after exponential "exit 1"
+$ concurrently -p time --restart-tries 3 --restart-after exponential 'exit 1'
 
 [2024-09-01 23:49:01.124] exit 1 exited with code 1
 [2024-09-01 23:49:02.127] exit 1 restarted

--- a/docs/cli/shortcuts.md
+++ b/docs/cli/shortcuts.md
@@ -35,9 +35,9 @@ For example, given the following `package.json` contents:
 It's possible to run some of these with the following command line:
 
 ```bash
-$ concurrently "pnpm:lint:js"
+$ concurrently 'pnpm:lint:js'
 # Is equivalent to
-$ concurrently -n lint:js "pnpm run lint:js"
+$ concurrently -n lint:js 'pnpm run lint:js'
 ```
 
 Note that the command automatically receives a name equal to the script name.
@@ -46,17 +46,17 @@ If you have several scripts with similar name patterns, you can use the `*` wild
 The spawned commands will receive names set to whatever the `*` wildcard matched.
 
 ```bash
-$ concurrently "npm:lint:fix:*"
+$ concurrently 'npm:lint:fix:*'
 # is equivalent to
-$ concurrently -n js,ts "npm run lint:fix:js" "npm run lint:fix:ts"
+$ concurrently -n js,ts 'npm run lint:fix:js' 'npm run lint:fix:ts'
 ```
 
 If you specify a command name when using wildcards, it'll be a prefix of what the `*` wildcard matched:
 
 ```bash
-$ concurrently -n fix: "npm:lint:fix:*"
+$ concurrently -n fix: 'npm:lint:fix:*'
 # is equivalent to
-$ concurrently -n fix:js,fix:ts "npm run lint:fix:js" "npm run lint:fix:ts"
+$ concurrently -n fix:js,fix:ts 'npm run lint:fix:js' 'npm run lint:fix:ts'
 ```
 
 Filtering out commands matched by wildcard is also possible. Do this with by including `(!<some pattern>)` in the command line:
@@ -64,7 +64,7 @@ Filtering out commands matched by wildcard is also possible. Do this with by inc
 ```bash
 $ concurrently 'yarn:lint:*(!fix)'
 # is equivalent to
-$ concurrently -n js,ts "yarn run lint:js" "yarn run lint:ts"
+$ concurrently -n js,ts 'yarn run lint:js' 'yarn run lint:ts'
 ```
 
 > [!NOTE]


### PR DESCRIPTION
It's generally a good practice to prefer single-quotes in shell script strings unless you plan on interpolating variables. 

It's purely stylistic here (even if you disregard that these are just markdown files 😅), but there's something about shell code that looks safer at first-glance. It's sorta like how a SQL query string _can_ be safe when concatenating another string directly onto it, but it doesn't _look_ as safe as one that escapes inputs.

Plus, given that the NPM scripts are already inside JSON strings, getting rid of escaped characters makes it look neater! :3