### PR TITLE
refactor: use startsWith & simplify boolean expression

### DIFF
--- a/bin/concurrently.spec.ts
+++ b/bin/concurrently.spec.ts
@@ -183,7 +183,7 @@ describe('exiting conditions', () => {
         // Windows doesn't support sending signals like on POSIX platforms.
         // However, in a console, processes can be interrupted with CTRL+C (like a SIGINT).
         // This is what we simulate here with the help of a wrapper application.
-        const child = run('"node fixtures/read-echo.js"', isWindows ? true : false);
+        const child = run('"node fixtures/read-echo.js"', isWindows);
         // Wait for command to have started before sending SIGINT
         child.log.subscribe((line) => {
             if (/READING/.test(line)) {

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -88,7 +88,7 @@ export const getSpawnOpts = ({
     return {
         cwd: cwd || process.cwd(),
         stdio: stdioValues,
-        ...(/^win/.test(process.platform) && { detached: false }),
+        ...(process.platform.startsWith('win') && { detached: false }),
         env: {
             ...(colorSupport ? { FORCE_COLOR: colorSupport.level.toString() } : {}),
             ...process.env,


### PR DESCRIPTION
- [Use 'String#startsWith' method instead.](https://sonarcloud.io/organizations/noritaka1166/rules?open=typescript%3AS6557&rule_key=typescript%3AS6557)
- [Unnecessary use of boolean literals in conditional expression.](https://sonarcloud.io/organizations/noritaka1166/rules?open=typescript%3AS6644&rule_key=typescript%3AS6644)