### PR TITLE
fix: correct typos in comments and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Check out documentation and other usage examples in the [`docs` directory](./doc
   with the shape `{ command, name, prefixColor, env, cwd, ipc }`.
 
 - `options` (optional): an object containing any of the below:
-  - `cwd`: the working directory to be used by all commands. Can be overriden per command.
+  - `cwd`: the working directory to be used by all commands. Can be overridden per command.
     Default: `process.cwd()`.
   - `defaultInputTarget`: the default input target when reading from `inputStream`.
     Default: `0`.
@@ -109,7 +109,7 @@ Check out documentation and other usage examples in the [`docs` directory](./doc
     Prefix colors specified per-command take precedence over this list.
   - `prefixLength`: how many characters to show when prefixing with `command`. Default: `10`
   - `raw`: whether raw mode should be used, meaning strictly process output will
-    be logged, without any prefixes, coloring or extra stuff. Can be overriden per command.
+    be logged, without any prefixes, coloring or extra stuff. Can be overridden per command.
   - `successCondition`: the condition to consider the run was successful.
     If `first`, only the first process to exit will make up the success of the run; if `last`, the last process that exits will determine whether the run succeeds.
     Anything else means all processes should exit successfully.

--- a/src/completion-listener.spec.ts
+++ b/src/completion-listener.spec.ts
@@ -81,7 +81,7 @@ describe('listen', () => {
         emitFakeCloseEvent(commands[0]);
 
         scheduler.flush();
-        // A broken implementantion will have called finallyCallback only after flushing promises
+        // A broken implementation will have called finallyCallback only after flushing promises
         await flushPromises();
         expect(finallyCallback).not.toHaveBeenCalled();
 
@@ -117,7 +117,7 @@ describe('listen', () => {
         emitFakeCloseEvent(commands[2]);
 
         scheduler.flush();
-        // A broken implementantion will have called finallyCallback only after flushing promises
+        // A broken implementation will have called finallyCallback only after flushing promises
         await flushPromises();
         expect(finallyCallback).not.toHaveBeenCalled();
 

--- a/src/completion-listener.ts
+++ b/src/completion-listener.ts
@@ -78,7 +78,7 @@ export class CompletionListener {
                 (event) => targetCommandsEvents.includes(event) || event.exitCode === 0,
             );
         }
-        // Only the specified commands must exit succesfully
+        // Only the specified commands must exit successfully
         return (
             targetCommandsEvents.length > 0 &&
             targetCommandsEvents.every((event) => event.exitCode === 0)

--- a/src/logger.spec.ts
+++ b/src/logger.spec.ts
@@ -316,7 +316,7 @@ describe('#logTable()', () => {
         expect(logger.log).not.toHaveBeenCalled();
     });
 
-    it('does not log anything if array is empy', () => {
+    it('does not log anything if array is empty', () => {
         const { logger } = createLogger({});
         logger.logTable([]);
 

--- a/src/prefix-color-selector.ts
+++ b/src/prefix-color-selector.ts
@@ -35,7 +35,7 @@ function* createColorGenerator(customColors: string[]): Generator<string, string
     const lastCustomColor = customColors[customColors.length - 1] || '';
     if (lastCustomColor !== 'auto') {
         while (true) {
-            yield lastCustomColor; // If last custom color was not "auto" then return same color forever, to maintain existing behaviour
+            yield lastCustomColor; // If last custom color was not "auto" then return same color forever, to maintain existing behavior
         }
     }
 


### PR DESCRIPTION
correct typos in comments and documentation