### PR TITLE
refactor: fix map and reduce as return values are not used

### DIFF
--- a/src/flow-control/restart-process.ts
+++ b/src/flow-control/restart-process.ts
@@ -53,7 +53,7 @@ export class RestartProcess implements FlowController {
                     takeWhile(({ exitCode }) => exitCode !== 0),
                 ),
             )
-            .map((failure, index) =>
+            .forEach((failure, index) =>
                 Rx.merge(
                     // Delay the emission (so that the restarts happen on time),
                     // explicitly telling the subscriber that a restart is needed

--- a/src/prefix-color-selector.spec.ts
+++ b/src/prefix-color-selector.spec.ts
@@ -155,12 +155,13 @@ describe('#getNextColor', function () {
             map ? expectedColors.map(() => 'auto') : ['auto'],
         );
 
-        expectedColors.reduce((previousColor, currentExpectedColor) => {
+        let previousColor = '';
+        for (const expectedColor of expectedColors) {
             const actualSelectedColor = prefixColorSelector.getNextColor();
             expect(actualSelectedColor).not.toBe(previousColor); // No consecutive colors
-            expect(actualSelectedColor).toBe(currentExpectedColor); // Expected color
-            return actualSelectedColor;
-        }, '');
+            expect(actualSelectedColor).toBe(expectedColor); // Expected color
+            previousColor = actualSelectedColor;
+        }
     });
 });
 


### PR DESCRIPTION
fix map and reduce as return values are not used