### PR TITLE
chore: update eslint-plugin-simple-import-sort from v10 to v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-simple-import-sort": "^10.0.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "husky": "^9.1.5",
     "jest": "^30.0.0",
     "jest-create-mock-instance": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ devDependencies:
     specifier: ^5.2.1
     version: 5.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.0.3)
   eslint-plugin-simple-import-sort:
-    specifier: ^10.0.0
-    version: 10.0.0(eslint@8.57.0)
+    specifier: ^12.1.1
+    version: 12.1.1(eslint@8.57.0)
   husky:
     specifier: ^9.1.5
     version: 9.1.5
@@ -2943,8 +2943,8 @@ packages:
       synckit: 0.9.1
     dev: true
 
-  /eslint-plugin-simple-import-sort@10.0.0(eslint@8.57.0):
-    resolution: {integrity: sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==}
+  /eslint-plugin-simple-import-sort@12.1.1(eslint@8.57.0):
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
     peerDependencies:
       eslint: '>=5.0.0'
     dependencies:


### PR DESCRIPTION
update eslint-plugin-simple-import-sort from v10 to v12
- <https://github.com/lydell/eslint-plugin-simple-import-sort/blob/main/CHANGELOG.md>