### PR TITLE
refactor: Replace lodash with es-toolkit

### DIFF
--- a/bin/concurrently.spec.ts
+++ b/bin/concurrently.spec.ts
@@ -1,9 +1,9 @@
 import { subscribeSpyTo } from '@hirez_io/observer-spy';
 import { spawn } from 'child_process';
 import { sendCtrlC, spawnWithWrapper } from 'ctrlc-wrapper';
+import { escapeRegExp } from 'es-toolkit/compat';
 import { build } from 'esbuild';
 import fs from 'fs';
-import { escapeRegExp } from 'lodash';
 import os from 'os';
 import path from 'path';
 import * as readline from 'readline';

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import _ from 'lodash';
+import _ from 'es-toolkit/compat';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.1.2",
-    "lodash": "^4.17.21",
+    "es-toolkit": "^1.39.5",
     "rxjs": "^7.8.1",
     "shell-quote": "^1.8.1",
     "supports-color": "^8.1.1",
@@ -70,7 +70,6 @@
     "@swc/core": "^1.7.23",
     "@swc/jest": "^0.2.36",
     "@types/jest": "^30.0.0",
-    "@types/lodash": "^4.17.7",
     "@types/node": "^18.19.50",
     "@types/shell-quote": "^1.7.5",
     "@types/supports-color": "^8.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ dependencies:
   chalk:
     specifier: ^4.1.2
     version: 4.1.2
-  lodash:
-    specifier: ^4.17.21
-    version: 4.17.21
+  es-toolkit:
+    specifier: ^1.39.5
+    version: 1.39.5
   rxjs:
     specifier: ^7.8.1
     version: 7.8.1
@@ -43,9 +43,6 @@ devDependencies:
   '@types/jest':
     specifier: ^30.0.0
     version: 30.0.0
-  '@types/lodash':
-    specifier: ^4.17.7
-    version: 4.17.7
   '@types/node':
     specifier: ^18.19.50
     version: 18.19.50
@@ -1604,10 +1601,6 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
-  /@types/lodash@4.17.7:
-    resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
-    dev: true
-
   /@types/node@18.19.50:
     resolution: {integrity: sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==}
     dependencies:
@@ -2758,6 +2751,10 @@ packages:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
     dev: true
+
+  /es-toolkit@1.39.5:
+    resolution: {integrity: sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==}
+    dev: false
 
   /esbuild@0.25.0:
     resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
@@ -4286,10 +4283,6 @@ packages:
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
-
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
 
   /log-driver@1.2.7:
     resolution: {integrity: sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==}

--- a/src/command-parser/expand-wildcard.ts
+++ b/src/command-parser/expand-wildcard.ts
@@ -1,5 +1,5 @@
+import _ from 'es-toolkit/compat';
 import fs from 'fs';
-import _ from 'lodash';
 
 import { CommandInfo } from '../command';
 import JSONC from '../jsonc';

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import _ from 'lodash';
+import _ from 'es-toolkit/compat';
 import { cpus } from 'os';
 import { takeUntil } from 'rxjs';
 import { Writable } from 'stream';
@@ -180,7 +180,7 @@ export function concurrently(
     }
 
     const hide = (options.hide || []).map(String);
-    let commands = _(baseCommands)
+    let commands = baseCommands
         .map(mapToCommandInfo)
         .flatMap((command) => parseCommand(command, commandParsers))
         .map((command, index) => {
@@ -200,8 +200,7 @@ export function concurrently(
                 options.spawn,
                 options.kill,
             );
-        })
-        .value();
+        });
 
     const handleResult = options.controllers.reduce(
         ({ commands: prevCommands, onFinishCallbacks }, controller) => {
@@ -241,7 +240,9 @@ export function concurrently(
         maybeRunMore(commandsLeft, options.abortSignal);
     }
 
-    const result = new CompletionListener({ successCondition: options.successCondition })
+    const result = new CompletionListener({
+        successCondition: options.successCondition,
+    })
         .listen(commands, options.abortSignal)
         .finally(() => Promise.all(handleResult.onFinishCallbacks.map((onFinish) => onFinish())));
 

--- a/src/flow-control/kill-others.ts
+++ b/src/flow-control/kill-others.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'es-toolkit/compat';
 import { filter, map } from 'rxjs/operators';
 
 import { Command } from '../command';

--- a/src/flow-control/log-timings.ts
+++ b/src/flow-control/log-timings.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import _ from 'lodash';
+import { sortBy } from 'es-toolkit/compat';
 import * as Rx from 'rxjs';
 import { bufferCount, combineLatestWith, take } from 'rxjs/operators';
 
@@ -56,11 +56,9 @@ export class LogTimings implements FlowController {
     private printExitInfoTimingTable(exitInfos: CloseEvent[]) {
         assert.ok(this.logger);
 
-        const exitInfoTable = _(exitInfos)
-            .sortBy(({ timings }) => timings.durationSeconds)
+        const exitInfoTable = sortBy(exitInfos, ({ timings }) => timings.durationSeconds)
             .reverse()
-            .map(LogTimings.mapCloseEventToTimingInfo)
-            .value();
+            .map(LogTimings.mapCloseEventToTimingInfo);
 
         this.logger.logGlobalEvent('Timings:');
         this.logger.logTable(exitInfoTable);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _ from 'es-toolkit/compat';
 import { Readable } from 'stream';
 
 import { assertDeprecated } from './assert';
@@ -189,7 +189,11 @@ export function concurrently(
                 logger: options.timings ? logger : undefined,
                 timestampFormat: options.timestampFormat,
             }),
-            new Teardown({ logger, spawn: options.spawn, commands: options.teardown || [] }),
+            new Teardown({
+                logger,
+                spawn: options.spawn,
+                commands: options.teardown || [],
+            }),
         ],
         prefixColors: options.prefixColors || [],
         additionalArguments: options.additionalArguments,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import chalk, { Chalk } from 'chalk';
-import _ from 'lodash';
+import _ from 'es-toolkit/compat';
 import * as Rx from 'rxjs';
 
 import { Command, CommandIdentifier } from './command';

--- a/tests/pnpm-lock.yaml
+++ b/tests/pnpm-lock.yaml
@@ -89,7 +89,7 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /lodash@4.17.21:
+  /es-toolkit/compat@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
@@ -195,7 +195,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       date-fns: 2.30.0
-      lodash: 4.17.21
+      es-toolkit/compat: 4.17.21
       rxjs: 7.8.1
       shell-quote: 1.8.1
       spawn-command: 0.0.2

--- a/tests/pnpm-lock.yaml
+++ b/tests/pnpm-lock.yaml
@@ -195,7 +195,7 @@ packages:
     dependencies:
       chalk: 4.1.2
       date-fns: 2.30.0
-      es-toolkit/compat: 4.17.21
+      es-toolkit: 1.39.5
       rxjs: 7.8.1
       shell-quote: 1.8.1
       spawn-command: 0.0.2

--- a/tests/pnpm-lock.yaml
+++ b/tests/pnpm-lock.yaml
@@ -69,6 +69,10 @@ packages:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: false
 
+  /es-toolkit@1.39.5:
+    resolution: {integrity: sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==}
+    dev: false
+
   /escalade@3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -87,10 +91,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: false
-
-  /es-toolkit/compat@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: false
 
   /regenerator-runtime@0.14.1:
@@ -190,6 +190,7 @@ packages:
   file:..:
     resolution: {directory: .., type: directory}
     name: concurrently
+    version: 9.2.0
     engines: {node: '>=18'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
es-toolkit is a modern alternative to lodash that's significantly faster and lighter, which could potentially boost concurrently's overall performance. It's been tested using lodash's actual test suite.

It's already being adopted by major projects like Storybook, Recharts, Ink, and CKEditor with 2.5M downloads a week on NPM.

You can learn more at https://es-toolkit.slash.page/intro.html.

## Test results

<img width="532" alt="image" src="https://github.com/user-attachments/assets/c3bddc3c-46ad-492d-9104-532b86bc35ff" />

