### PR TITLE
Remove lodash

### DIFF
--- a/bin/concurrently.spec.ts
+++ b/bin/concurrently.spec.ts
@@ -3,13 +3,14 @@ import { spawn } from 'child_process';
 import { sendCtrlC, spawnWithWrapper } from 'ctrlc-wrapper';
 import { build } from 'esbuild';
 import fs from 'fs';
-import { escapeRegExp } from 'lodash';
 import os from 'os';
 import path from 'path';
 import * as readline from 'readline';
 import * as Rx from 'rxjs';
 import { map } from 'rxjs/operators';
 import stringArgv from 'string-argv';
+
+import { escapeRegExp } from '../src/utils';
 
 const isWindows = process.platform === 'win32';
 const createKillMessage = (prefix: string, signal: 'SIGTERM' | 'SIGINT' | string) => {

--- a/bin/concurrently.ts
+++ b/bin/concurrently.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-import _ from 'lodash';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import { assertDeprecated } from '../src/assert';
 import * as defaults from '../src/defaults';
 import { concurrently } from '../src/index';
+import { castArray } from '../src/utils';
 import { readPackage } from './read-package';
 
 const version = String(readPackage().version);
@@ -226,7 +226,7 @@ assertDeprecated(
 // Get names of commands by the specified separator
 const names = (args.names || '').split(args.nameSeparator);
 
-const additionalArguments = _.castArray(args['--'] ?? []).map(String);
+const additionalArguments = castArray(args['--'] ?? []).map(String);
 const commands = args.passthroughArguments ? args._ : args._.concat(additionalArguments);
 
 if (!commands.length) {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^4.1.2",
-    "lodash": "^4.17.21",
     "rxjs": "^7.8.1",
     "shell-quote": "^1.8.1",
     "supports-color": "^8.1.1",
@@ -70,7 +69,6 @@
     "@swc/core": "^1.7.23",
     "@swc/jest": "^0.2.36",
     "@types/jest": "^30.0.0",
-    "@types/lodash": "^4.17.7",
     "@types/node": "^18.19.50",
     "@types/shell-quote": "^1.7.5",
     "@types/supports-color": "^8.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ dependencies:
   chalk:
     specifier: ^4.1.2
     version: 4.1.2
-  lodash:
-    specifier: ^4.17.21
-    version: 4.17.21
   rxjs:
     specifier: ^7.8.1
     version: 7.8.1
@@ -43,9 +40,6 @@ devDependencies:
   '@types/jest':
     specifier: ^30.0.0
     version: 30.0.0
-  '@types/lodash':
-    specifier: ^4.17.7
-    version: 4.17.7
   '@types/node':
     specifier: ^18.19.50
     version: 18.19.50
@@ -1602,10 +1596,6 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
-    dev: true
-
-  /@types/lodash@4.17.7:
-    resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
     dev: true
 
   /@types/node@18.19.50:
@@ -4286,10 +4276,6 @@ packages:
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
-
-  /lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
 
   /log-driver@1.2.7:
     resolution: {integrity: sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==}

--- a/src/command-parser/expand-wildcard.ts
+++ b/src/command-parser/expand-wildcard.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
-import _ from 'lodash';
 
 import { CommandInfo } from '../command';
 import JSONC from '../jsonc';
+import { escapeRegExp } from '../utils';
 import { CommandParser } from './command-parser';
 
 // Matches a negative filter surrounded by '(!' and ')'.
@@ -89,8 +89,8 @@ export class ExpandWildcard implements CommandParser {
 
         const [, omission] = OMISSION.exec(scriptGlob) || [];
         const scriptGlobSansOmission = scriptGlob.replace(OMISSION, '');
-        const preWildcard = _.escapeRegExp(scriptGlobSansOmission.slice(0, wildcardPosition));
-        const postWildcard = _.escapeRegExp(scriptGlobSansOmission.slice(wildcardPosition + 1));
+        const preWildcard = escapeRegExp(scriptGlobSansOmission.slice(0, wildcardPosition));
+        const postWildcard = escapeRegExp(scriptGlobSansOmission.slice(wildcardPosition + 1));
         const wildcardRegex = new RegExp(`^${preWildcard}(.*?)${postWildcard}$`);
         // If 'commandInfo.name' doesn't match 'scriptGlob', this means a custom name
         // has been specified and thus becomes the prefix (as described in the README).

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -181,7 +181,7 @@ export function concurrently(
     }
 
     const hide = (options.hide || []).map(String);
-    let commands = _(baseCommands)
+    let commands = baseCommands
         .map(mapToCommandInfo)
         .flatMap((command) => parseCommand(command, commandParsers))
         .map((command, index) => {
@@ -201,8 +201,7 @@ export function concurrently(
                 options.spawn,
                 options.kill,
             );
-        })
-        .value();
+        });
 
     const handleResult = options.controllers.reduce(
         ({ commands: prevCommands, onFinishCallbacks }, controller) => {

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -208,7 +208,7 @@ export function concurrently(
             const { commands, onFinish } = controller.handle(prevCommands);
             return {
                 commands,
-                onFinishCallbacks: _.concat(onFinishCallbacks, onFinish ? [onFinish] : []),
+                onFinishCallbacks: onFinishCallbacks.concat(onFinish ? [onFinish] : []),
             };
         },
         { commands, onFinishCallbacks: [] } as {
@@ -278,7 +278,7 @@ function mapToCommandInfo(command: ConcurrentlyCommandInput): CommandInfo {
 
 function parseCommand(command: CommandInfo, parsers: CommandParser[]) {
     return parsers.reduce(
-        (commands, parser) => _.flatMap(commands, (command) => parser.parse(command)),
+        (commands, parser) => commands.flatMap((command) => parser.parse(command)),
         castArray(command),
     );
 }

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -24,6 +24,7 @@ import { Logger } from './logger';
 import { OutputWriter } from './output-writer';
 import { PrefixColorSelector } from './prefix-color-selector';
 import { getSpawnOpts, spawn } from './spawn';
+import { castArray } from './utils';
 
 const defaults: ConcurrentlyOptions = {
     spawn,
@@ -279,7 +280,7 @@ function mapToCommandInfo(command: ConcurrentlyCommandInput): CommandInfo {
 function parseCommand(command: CommandInfo, parsers: CommandParser[]) {
     return parsers.reduce(
         (commands, parser) => _.flatMap(commands, (command) => parser.parse(command)),
-        _.castArray(command),
+        castArray(command),
     );
 }
 

--- a/src/concurrently.ts
+++ b/src/concurrently.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import _ from 'lodash';
 import { cpus } from 'os';
 import { takeUntil } from 'rxjs';
 import { Writable } from 'stream';
@@ -166,7 +165,7 @@ export function concurrently(
     assert.ok(Array.isArray(baseCommands), '[concurrently] commands should be an array');
     assert.notStrictEqual(baseCommands.length, 0, '[concurrently] no commands provided');
 
-    const options = _.defaults(baseOptions, defaults);
+    const options = { ...defaults, ...baseOptions };
 
     const prefixColorSelector = new PrefixColorSelector(options.prefixColors || []);
 

--- a/src/flow-control/kill-others.ts
+++ b/src/flow-control/kill-others.ts
@@ -1,8 +1,8 @@
-import _ from 'lodash';
 import { filter, map } from 'rxjs/operators';
 
 import { Command } from '../command';
 import { Logger } from '../logger';
+import { castArray } from '../utils';
 import { FlowController } from './flow-controller';
 
 export type ProcessCloseCondition = 'failure' | 'success';
@@ -32,7 +32,7 @@ export class KillOthers implements FlowController {
     }) {
         this.logger = logger;
         this.abortController = abortController;
-        this.conditions = _.castArray(conditions);
+        this.conditions = castArray(conditions);
         this.killSignal = killSignal;
         this.timeoutMs = timeoutMs;
     }

--- a/src/flow-control/log-timings.ts
+++ b/src/flow-control/log-timings.ts
@@ -1,5 +1,4 @@
 import * as assert from 'assert';
-import _ from 'lodash';
 import * as Rx from 'rxjs';
 import { bufferCount, combineLatestWith, take } from 'rxjs/operators';
 
@@ -56,11 +55,9 @@ export class LogTimings implements FlowController {
     private printExitInfoTimingTable(exitInfos: CloseEvent[]) {
         assert.ok(this.logger);
 
-        const exitInfoTable = _(exitInfos)
-            .sortBy(({ timings }) => timings.durationSeconds)
-            .reverse()
-            .map(LogTimings.mapCloseEventToTimingInfo)
-            .value();
+        const exitInfoTable = exitInfos
+            .sort((a, b) => b.timings.durationSeconds - a.timings.durationSeconds)
+            .map(LogTimings.mapCloseEventToTimingInfo);
 
         this.logger.logGlobalEvent('Timings:');
         this.logger.logTable(exitInfoTable);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { Readable } from 'stream';
 
 import { assertDeprecated } from './assert';
@@ -22,6 +21,7 @@ import { OutputErrorHandler } from './flow-control/output-error-handler';
 import { RestartDelay, RestartProcess } from './flow-control/restart-process';
 import { Teardown } from './flow-control/teardown';
 import { Logger } from './logger';
+import { castArray } from './utils';
 
 export type ConcurrentlyOptions = Omit<BaseConcurrentlyOptions, 'abortSignal' | 'hide'> & {
     // Logger options
@@ -130,7 +130,7 @@ export function concurrently(
     // To avoid empty strings from hiding the output of commands that don't have a name,
     // keep in the list of commands to hide only strings with some length.
     // This might happen through the CLI when no `--hide` argument is specified, for example.
-    const hide = _.castArray(options.hide).filter((id) => id || id === 0);
+    const hide = castArray(options.hide).filter((id) => id || id === 0);
     const logger =
         options.logger ||
         new Logger({

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,4 @@
 import chalk, { Chalk } from 'chalk';
-import _ from 'lodash';
 import * as Rx from 'rxjs';
 
 import { Command, CommandIdentifier } from './command';
@@ -9,6 +8,12 @@ import { escapeRegExp } from './utils';
 
 const defaultChalk = chalk;
 const noColorChalk = new chalk.Instance({ level: 0 });
+
+function getChalkPath(chalk: Chalk, path: string): Chalk | undefined {
+    return path
+        .split('.')
+        .reduce((prev, key) => (prev as unknown as Record<string, Chalk>)[key], chalk);
+}
 
 export class Logger {
     private readonly hide: CommandIdentifier[];
@@ -153,8 +158,9 @@ export class Logger {
         if (command.prefixColor?.startsWith('#')) {
             color = this.chalk.hex(command.prefixColor);
         } else {
-            const defaultColor = _.get(this.chalk, defaults.prefixColors, this.chalk.reset);
-            color = _.get(this.chalk, command.prefixColor ?? '', defaultColor);
+            const defaultColor =
+                getChalkPath(this.chalk, defaults.prefixColors) ?? this.chalk.reset;
+            color = getChalkPath(this.chalk, command.prefixColor ?? '') ?? defaultColor;
         }
         return color(text);
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -5,6 +5,7 @@ import * as Rx from 'rxjs';
 import { Command, CommandIdentifier } from './command';
 import { DateFormatter } from './date-format';
 import * as defaults from './defaults';
+import { escapeRegExp } from './utils';
 
 const defaultChalk = chalk;
 const noColorChalk = new chalk.Instance({ level: 0 });
@@ -128,7 +129,7 @@ export class Logger {
         const value = _.reduce(
             prefixes,
             (prev, val, key) => {
-                const keyRegex = new RegExp(_.escapeRegExp(`{${key}}`), 'g');
+                const keyRegex = new RegExp(escapeRegExp(`{${key}}`), 'g');
                 return prev.replace(keyRegex, String(val));
             },
             prefix,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -126,14 +126,10 @@ export class Logger {
             return { type: 'default', value: prefixes[prefix] };
         }
 
-        const value = _.reduce(
-            prefixes,
-            (prev, val, key) => {
-                const keyRegex = new RegExp(escapeRegExp(`{${key}}`), 'g');
-                return prev.replace(keyRegex, String(val));
-            },
-            prefix,
-        );
+        const value = Object.entries(prefixes).reduce((prev, [key, val]) => {
+            const keyRegex = new RegExp(escapeRegExp(`{${key}}`), 'g');
+            return prev.replace(keyRegex, String(val));
+        }, prefix);
         return { type: 'template', value };
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,3 +4,10 @@
 export function escapeRegExp(str: string) {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+/**
+ * Casts a value to an array if it's not one.
+ */
+export function castArray<T>(value?: T | readonly T[]): readonly T[] {
+    return Array.isArray(value) ? value : value ? [value as T] : [];
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,6 @@
+/**
+ * Escapes a string for use in a regular expression.
+ */
+export function escapeRegExp(str: string) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,6 @@ export function escapeRegExp(str: string) {
 /**
  * Casts a value to an array if it's not one.
  */
-export function castArray<T>(value?: T | readonly T[]): readonly T[] {
+export function castArray<T>(value?: T | readonly T[]): T[] {
     return Array.isArray(value) ? value : value ? [value as T] : [];
 }


### PR DESCRIPTION
- Functions with native drop-in or simple-enough-alternative (e.g. `sortBy`) have been replaced with the native version;
- Functions simple to maintain and used a lot have been bundled in an `utils.ts` file with a bespoke version;
- Functions not as simple to maintain and not used much have been migrated inline, e.g. `_.get()` or `_.defaults()`