### PR TITLE
Rename killOthers to killOthersOn in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const { result } = concurrently(
   ],
   {
     prefix: 'name',
-    killOthers: ['failure', 'success'],
+    killOthersOn: ['failure', 'success'],
     restartTries: 3,
     cwd: path.resolve(__dirname, 'scripts'),
   },


### PR DESCRIPTION
My understanding is that `killOthers` is deprecated