### PR TITLE
Clarify usage of `makeTests()`

### DIFF
--- a/src/date-format.spec.ts
+++ b/src/date-format.spec.ts
@@ -7,6 +7,17 @@ const withDate = (date: string) => `${date}T00:00:00`;
 
 type TokenTests = undefined | { input: string; expected: string }[];
 
+/**
+ * Generates a suite of tests for token `token`.
+ *
+ * Each entry in `patternTests` makes the token longer, e.g.
+ * ```
+ * makeTests('era', 'G', [
+ *   [/* test cases */], // G
+ *   [/* test cases */], // GG
+ *   [/* test cases */], // GGG
+ * ```
+ */
 const makeTests = (
     name: string,
     token: string,
@@ -29,7 +40,7 @@ const makeTests = (
                 ({ expected, input }) => {
                     const formatter = new DateFormatter(pattern, {
                         locale: 'en',
-                        calendar: 'gregoy',
+                        calendar: 'gregory',
                         ...options,
                     });
                     expect(formatter.format(new Date(input))).toBe(expected);


### PR DESCRIPTION
Victim of the "will I remember what this means in 6 months" - the answer was no when reviewing #565, so this PR makes `makeTests()` in `date-formatter.spec.ts` clearer.

Also fixes one typo.