### PR TITLE
[Readme] add note about windows only supporting double quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,16 @@ concurrently 'command1 arg' 'command2 arg'
 Otherwise **concurrently** would try to run 4 separate commands:
 `command1`, `arg`, `command2`, `arg`.
 
-In package.json, escape quotes:
-
-```bash
-"start": "concurrently 'command1 arg' 'command2 arg'"
-```
+> [!IMPORTANT]
+> Windows only supports double quotes:
+> ```bash
+> concurrently "command1 arg" "command2 arg"
+> ```
+>
+> Remember to escape the double quotes in your package.json when using Windows:
+> ```json
+> "start": "concurrently \"command1 arg\" \"command2 arg\""
+> ```
 
 You can always check concurrently's flag list by running `concurrently --help`.
 For the version, run `concurrently --version`.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ Otherwise **concurrently** would try to run 4 separate commands:
 
 > [!IMPORTANT]
 > Windows only supports double quotes:
+> 
 > ```bash
 > concurrently "command1 arg" "command2 arg"
 > ```
 >
 > Remember to escape the double quotes in your package.json when using Windows:
+> 
 > ```json
 > "start": "concurrently \"command1 arg\" \"command2 arg\""
 > ```

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ Otherwise **concurrently** would try to run 4 separate commands:
 
 > [!IMPORTANT]
 > Windows only supports double quotes:
-> 
+>
 > ```bash
 > concurrently "command1 arg" "command2 arg"
 > ```
 >
 > Remember to escape the double quotes in your package.json when using Windows:
-> 
+>
 > ```json
 > "start": "concurrently \"command1 arg\" \"command2 arg\""
 > ```


### PR DESCRIPTION
fix #575 

Removed the original section about escaping the quotes, since in the given example there was no escaping happening and rephrased it in the note about Windows only supporting double quotes:

# Before:
In package.json, escape quotes:

```bash
"start": "concurrently 'command1 arg' 'command2 arg'"
```

# After:
> [!IMPORTANT]
> Windows only supports double quotes:
>
> ```bash
>
> concurrently "command1 arg" "command2 arg"
> ```
>
> Remember to escape the double quotes in your package.json when using Windows:
>
> ```json
> "start": "concurrently \"command1 arg\" \"command2 arg\""
> ```
