### PR TITLE
feat: enable automatic prefix colors by default

### DIFF
--- a/docs/cli/prefixing.md
+++ b/docs/cli/prefixing.md
@@ -56,10 +56,10 @@ $ concurrently --prefix '{index}-{pid}' 'echo Hello there' 'echo General Kenobi!
 
 ## Prefix Colors
 
-By default, there are no colors applied to concurrently prefixes, and they just use whatever the terminal's defaults are.
+By default, concurrently automatically assigns colors to each command's prefix, cycling through `cyan`, `magenta`, `green`, `yellow`, and `blue` (the same palette and order used by turborepo).
 
 This can be changed by using the `--prefix-colors`/`-c` flag, which takes a comma-separated list of colors to use.<br/>
-The available values are color names (e.g. `green`, `magenta`, `gray`, etc), a hex value (such as `#23de43`), or `auto`, to automatically select a color.
+The available values are color names (e.g. `green`, `magenta`, `gray`, etc), a hex value (such as `#23de43`), `auto` to automatically select a color, or `reset` to disable coloring.
 
 ```bash
 $ concurrently -c red,blue 'echo Hello there' 'echo General Kenobi!'

--- a/lib/defaults.ts
+++ b/lib/defaults.ts
@@ -35,7 +35,7 @@ export const prefix = '';
  * Default prefix color.
  * @see https://www.npmjs.com/package/chalk
  */
-export const prefixColors = 'reset';
+export const prefixColors = 'auto';
 
 /**
  * How many bytes we'll show on the command prefix.

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -166,7 +166,8 @@ export class Logger {
                 color = modifiedColor;
             }
         } else {
-            const defaultColor = getChalkPath(this.chalk, defaults.prefixColors) as ChalkInstance;
+            const defaultColor =
+                getChalkPath(this.chalk, defaults.prefixColors) ?? this.chalk.reset;
             color = getChalkPath(this.chalk, command.prefixColor ?? '') ?? defaultColor;
         }
         return color(text);

--- a/lib/prefix-color-selector.spec.ts
+++ b/lib/prefix-color-selector.spec.ts
@@ -181,7 +181,7 @@ describe('#ACCEPTABLE_CONSOLE_COLORS', () => {
         expect(PrefixColorSelector.ACCEPTABLE_CONSOLE_COLORS.length).toBeGreaterThan(1);
     });
 
-    it('uses the same color order as turborepo', () => {
+    it('uses the same colors and order as turborepo', () => {
         expect(PrefixColorSelector.ACCEPTABLE_CONSOLE_COLORS).toEqual([
             'cyan',
             'magenta',

--- a/lib/prefix-color-selector.spec.ts
+++ b/lib/prefix-color-selector.spec.ts
@@ -180,4 +180,14 @@ describe('#ACCEPTABLE_CONSOLE_COLORS', () => {
         //     always has more than one entry, which is what we enforce via this test
         expect(PrefixColorSelector.ACCEPTABLE_CONSOLE_COLORS.length).toBeGreaterThan(1);
     });
+
+    it('uses the same color order as turborepo', () => {
+        expect(PrefixColorSelector.ACCEPTABLE_CONSOLE_COLORS).toEqual([
+            'cyan',
+            'magenta',
+            'green',
+            'yellow',
+            'blue',
+        ]);
+    });
 });

--- a/lib/prefix-color-selector.spec.ts
+++ b/lib/prefix-color-selector.spec.ts
@@ -181,7 +181,7 @@ describe('#ACCEPTABLE_CONSOLE_COLORS', () => {
         expect(PrefixColorSelector.ACCEPTABLE_CONSOLE_COLORS.length).toBeGreaterThan(1);
     });
 
-    it('uses the same colors and order as turborepo', () => {
+    it('only includes colors that are visually distinct, semantically neutral, and lightweight', () => {
         expect(PrefixColorSelector.ACCEPTABLE_CONSOLE_COLORS).toEqual([
             'cyan',
             'magenta',

--- a/lib/prefix-color-selector.ts
+++ b/lib/prefix-color-selector.ts
@@ -63,33 +63,19 @@ export class PrefixColorSelector {
         this.colorGenerator = createColorGenerator(normalizedColors);
     }
 
-    /** A list of colors that are readable in a terminal. */
+    /**
+     * Colors used by `auto` selection and default cycling.
+     *
+     * Matches turborepo's palette: cyan, magenta, green, yellow, blue.
+     * These are visually distinct on both dark and light terminal backgrounds
+     * without carrying semantic meaning (unlike red → errors) or blending
+     * into the default text color (unlike white/grey).
+     *
+     * This list does NOT restrict manually specified colors — any valid Chalk
+     * color name, hex value, or modifier can be passed via `--prefix-colors`.
+     */
     public static get ACCEPTABLE_CONSOLE_COLORS() {
-        // Colors picked randomly, can be amended if required
-        return [
-            // Prevent duplicates, in case the list becomes significantly large
-            ...new Set<keyof ChalkInstance>([
-                // Text colors
-                'cyan',
-                'yellow',
-                'greenBright',
-                'blueBright',
-                'magentaBright',
-                'white',
-                'grey',
-                'red',
-
-                // Background colors
-                'bgCyan',
-                'bgYellow',
-                'bgGreenBright',
-                'bgBlueBright',
-                'bgMagenta',
-                'bgWhiteBright',
-                'bgGrey',
-                'bgRed',
-            ]),
-        ];
+        return [...new Set<keyof ChalkInstance>(['cyan', 'magenta', 'green', 'yellow', 'blue'])];
     }
 
     /**

--- a/lib/prefix-color-selector.ts
+++ b/lib/prefix-color-selector.ts
@@ -66,10 +66,10 @@ export class PrefixColorSelector {
     /**
      * Colors used by `auto` selection and default cycling.
      *
-     * Matches turborepo's palette: cyan, magenta, green, yellow, blue.
-     * These are visually distinct on both dark and light terminal backgrounds
-     * without carrying semantic meaning (unlike red → errors) or blending
-     * into the default text color (unlike white/grey).
+     * Each color is chosen to be visually distinct on both dark and light
+     * terminal backgrounds, without carrying semantic meaning (e.g. red
+     * implies errors) or blending into default text (e.g. white/grey).
+     * Background colors are excluded to keep output lightweight.
      *
      * This list does NOT restrict manually specified colors — any valid Chalk
      * color name, hex value, or modifier can be passed via `--prefix-colors`.


### PR DESCRIPTION
## Summary

- Changes the default `--prefix-colors` from `reset` (no colors) to `auto`, so each command gets a distinct prefix color out of the box.
- Sets the auto-cycling palette to **cyan, magenta, green, yellow, blue**.
- Fixes the logger's `colorText` fallback to handle non-Chalk values in `defaults.prefixColors` gracefully.

## Motivation

Running `concurrently "cmd1" "cmd2" "cmd3"` today produces uncolored prefixes — all `[0]`, `[1]`, `[2]` look the same unless the user explicitly passes `-c auto` or a color list. Colored prefixes are one of the most useful visual cues when scanning interleaved output, yet they require opting in.

This PR makes colors the default. Users who prefer uncolored output can pass `-c reset`.

### Color choice rationale

The previous `ACCEPTABLE_CONSOLE_COLORS` list had 16 entries including colors that are problematic as defaults:

- **`white` / `grey`** blend into the terminal's default text color on most themes, looking effectively uncolored.
- **`red`** is universally associated with errors; using it for normal output creates a false sense of alarm.
- **`bg*` colors** (background-colored text) are visually heavy and distracting for everyday use.

The chosen 5-color palette avoids all of these: each color is clearly distinguishable, reads well on both dark and light backgrounds, and carries no semantic baggage. This is the same set of colors used by turborepo, which served as inspiration for the selection.

### Default pool vs allowed colors

`ACCEPTABLE_CONSOLE_COLORS` controls what `auto` picks from — it is **not** a whitelist. Manually specified colors via `--prefix-colors` remain completely unrestricted: any valid Chalk color name (`red`, `bgCyan`, `greenBright`, …), hex value (`#23de43`), or modifier (`bold`, `inverse`, …) works exactly as before. This distinction is now documented in the source.

## Changes

| File | What changed |
|------|-------------|
| `lib/defaults.ts` | `prefixColors`: `'reset'` → `'auto'` |
| `lib/prefix-color-selector.ts` | `ACCEPTABLE_CONSOLE_COLORS` → 5-color palette with updated JSDoc |
| `lib/logger.ts` | `colorText` fallback: `?? this.chalk.reset` for safety |
| `lib/prefix-color-selector.spec.ts` | New test asserting palette matches the expected 5 colors |
| `docs/cli/prefixing.md` | Updated to describe the new default behavior |

## Testing

```bash
pnpm test -- --run lib/prefix-color-selector.spec.ts
```

To see the colors locally:

```bash
pnpm build && node dist/bin/index.js "echo cmd1" "echo cmd2" "echo cmd3" "echo cmd4" "echo cmd5" "echo cmd6" "echo cmd7"
```

Commands 6 and 7 cycle back to cyan and magenta. Manual colors still work:

```bash
node dist/bin/index.js -c "red,bgCyan,white" "echo a" "echo b" "echo c"
```

All 583 tests pass (582 existing + 1 new). Lint and type checks clean.

### Screenshots to visualize the colors

<img width="478" height="428" alt="image" src="https://github.com/user-attachments/assets/d189509e-0180-43bf-94e1-886073fb430d" />

Example from the repo:

<img width="400" height="170" alt="image" src="https://github.com/user-attachments/assets/df3d8af1-a753-4b54-973c-7f87b8c41c43" />

