### PR TITLE
fix: propagate SIGINT exit status on POSIX

### DIFF
--- a/bin/index.spec.ts
+++ b/bin/index.spec.ts
@@ -185,7 +185,7 @@ describe('exiting conditions', () => {
         expect(exit.code).toBeGreaterThan(0);
     });
 
-    it('is of success when a SIGINT is sent', async () => {
+    it('propagates SIGINT on POSIX when interrupted', async () => {
         // Windows doesn't support sending signals like on POSIX platforms.
         // However, in a console, processes can be interrupted with CTRL+C (like a SIGINT).
         // This is what we simulate here with the help of a wrapper application.
@@ -204,7 +204,9 @@ describe('exiting conditions', () => {
         const lines = await child.getLogLines();
         const exit = await child.exit;
 
-        expect(exit.code).toBe(0);
+        expect(exit).toMatchObject(
+            isWindows ? { code: 0, signal: null } : { code: null, signal: 'SIGINT' },
+        );
         expect(lines).toContainEqual(
             expect.stringMatching(
                 createKillMessage(

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -225,6 +225,15 @@ assertDeprecated(
     'Use commas as name separators instead.',
 );
 
+let interruptedBySigint = false;
+if (process.platform !== 'win32') {
+    // On POSIX, exit with SIGINT after children finish so shell callers don't treat Ctrl+C as
+    // a successful run.
+    process.once('SIGINT', () => {
+        interruptedBySigint = true;
+    });
+}
+
 // Get names of commands by the specified separator
 const names = (args.names || '').split(args.nameSeparator);
 
@@ -269,6 +278,6 @@ concurrently(
         additionalArguments: args.passthroughArguments ? additionalArguments : undefined,
     },
 ).result.then(
-    () => process.exit(0),
-    () => process.exit(1),
+    () => (interruptedBySigint ? process.kill(process.pid, 'SIGINT') : process.exit(0)),
+    () => (interruptedBySigint ? process.kill(process.pid, 'SIGINT') : process.exit(1)),
 );


### PR DESCRIPTION
Fixes #470

When `concurrently` itself receives `SIGINT` on POSIX, it currently exits with code `0` after shutting down its children. That makes shell callers treat Ctrl+C as success, so `&&` chains continue running.

This keeps the existing shutdown flow for child commands, but once the run finishes it re-sends `SIGINT` to the `concurrently` process on POSIX so the parent shell observes an interrupted command instead of a successful exit. Windows behavior stays unchanged.

Validation:
- `pnpm build`
- `pnpm test -- --run bin/index.spec.ts -t 'propagates SIGINT on POSIX when interrupted'`
- Reproduced the issue before and after with `bash -lc 'node dist/bin/index.js "exec sleep 1000" "exec sleep 2000" && echo STILL_HERE'` and a `SIGINT` sent to the process group: before the patch it printed `STILL_HERE`, after the patch it exited with `SIGINT` and did not print it
