### PR TITLE
deps: upgrade shell-quote to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "chalk": "5.6.2",
     "rxjs": "7.8.2",
-    "shell-quote": "1.8.4",
+    "shell-quote": "1.9.0",
     "supports-color": "10.2.2",
     "tree-kill": "1.2.2",
     "yargs": "18.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 7.8.2
         version: 7.8.2
       shell-quote:
-        specifier: 1.8.4
-        version: 1.8.4
+        specifier: 1.9.0
+        version: 1.9.0
       supports-color:
         specifier: 10.2.2
         version: 10.2.2
@@ -1144,8 +1144,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -2323,7 +2323,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.9.0: {}
 
   siginfo@2.0.0: {}
 


### PR DESCRIPTION
## Summary

Bumps `shell-quote` from `1.8.4` to `1.9.0`. The only consumer in this
codebase is [lib/command-parser/expand-arguments.ts](lib/command-parser/expand-arguments.ts),
which uses `quote()` to escape the additional arguments substituted
into `{1}` / `{@}` / `{*}` placeholders.

Refs open-cli-tools/concurrently#597

## Security

Pulls in fix for [GHSA-395f-4hp3-45gv](https://github.com/ljharb/shell-quote/security/advisories/GHSA-395f-4hp3-45gv)
/ CVE-2026-13311 — quadratic-time DoS in `parse()` (High, CVSS 7.5),
affected versions ≤ 1.8.4.

Note: `concurrently` only consumes `quote()`, so this codebase is not
directly exposed to the `parse()` DoS. The upgrade also picks up a
behavior change in `quote()` that escapes a leading `~` to prevent
unintended shell tilde-expansion, which is relevant to the
`{1}` / `{@}` / `{*}` placeholder pipeline.

## Verification

- `pnpm typecheck` — passes
- `pnpm test` — 630 unit tests passing across 28 files
- `pnpm test:smoke` — 4 smoke tests passing
- `pnpm build` — succeeds
- Manual CLI run:
  `./dist/bin/index.js -P 'echo arg is {1} all are {@}' -- foo bar`
  → `arg is foo all are foo bar`

## Test plan

- [x] Type check
- [x] Unit tests
- [x] Smoke tests
- [x] Manual placeholder expansion sanity check