### PR TITLE
fix: avoid kill timeout exit delays

### DIFF
--- a/lib/flow-control/kill-others.spec.ts
+++ b/lib/flow-control/kill-others.spec.ts
@@ -133,3 +133,19 @@ it('force kills misbehaving processes after a timeout', () => {
     expect(commands[1].kill).toHaveBeenCalledWith('SIGKILL');
     expect(commands[2].kill).toHaveBeenCalledTimes(1);
 });
+
+it('does not keep the event loop alive while waiting to force kill', () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    createWithConditions(['failure'], { timeoutMs: 60_000 }).handle(commands);
+    assignProcess(commands[1]);
+    commands[0].close.next(createFakeCloseEvent({ exitCode: 1 }));
+
+    const timeout = setTimeoutSpy.mock.results.at(-1)?.value as NodeJS.Timeout;
+    try {
+        expect(timeout.hasRef()).toBe(false);
+    } finally {
+        clearTimeout(timeout);
+        setTimeoutSpy.mockRestore();
+    }
+});

--- a/lib/flow-control/kill-others.ts
+++ b/lib/flow-control/kill-others.ts
@@ -87,6 +87,6 @@ export class KillOthers implements FlowController {
                 );
                 killableCommands.forEach((command) => command.kill('SIGKILL'));
             }
-        }, this.timeoutMs);
+        }, this.timeoutMs).unref();
     }
 }


### PR DESCRIPTION
## Summary

- release the kill-timeout timer's event-loop reference
- add regression coverage for cooperative processes that stop before force-kill is needed

## Problem

When `killTimeout` is enabled, `KillOthers` schedules a referenced timer before sending the initial termination signal. If all targeted processes stop cooperatively, that timer is the only remaining active handle and keeps `concurrently` running until the full timeout expires.

## Fix

Unreference the force-kill timer. A child process that is still running continues to keep Node alive, so the timer can still deliver `SIGKILL`; once every child has stopped, the timer no longer delays exit.

## Testing

- `pnpm exec vitest run --project unit lib/flow-control/kill-others.spec.ts`
- `pnpm test`
- `pnpm exec vitest --coverage`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec prettier --check "**/*.{json,y?(a)ml,md}"`
- `pnpm build`
- `pnpm test:smoke`
