### PR TITLE
fix: correctly output non-ASCII text on Windows

### DIFF
--- a/bin/console-codepage.spec.ts
+++ b/bin/console-codepage.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ensureUtf8Codepage, SpawnSync } from './console-codepage.js';
+
+const win32 = { platform: 'win32' as const };
+const linux = { platform: 'linux' as const };
+
+const ok = (stdout: string) => ({ status: 0, stdout, error: undefined });
+const failed = () => ({ status: 1, stdout: '', error: undefined });
+
+describe('ensureUtf8Codepage()', () => {
+    it('does nothing on non-Windows platforms', () => {
+        const spawnSync = vi.fn();
+        ensureUtf8Codepage(spawnSync as unknown as SpawnSync, linux)();
+        expect(spawnSync).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when the codepage is already UTF-8', () => {
+        const spawnSync = vi.fn().mockReturnValue(ok('Active code page: 65001.'));
+        const restore = ensureUtf8Codepage(spawnSync as unknown as SpawnSync, win32);
+
+        expect(spawnSync).toHaveBeenCalledTimes(1);
+
+        restore();
+        expect(spawnSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('sets the codepage to UTF-8 and restores the original one it read', () => {
+        const spawnSync = vi.fn().mockReturnValue(ok('Aktive Codepage: 850.'));
+        const restore = ensureUtf8Codepage(spawnSync as unknown as SpawnSync, win32);
+
+        expect(spawnSync).toHaveBeenNthCalledWith(1, 'cmd.exe', ['/s', '/c', 'chcp'], {
+            encoding: 'utf8',
+        });
+        expect(spawnSync).toHaveBeenNthCalledWith(2, 'cmd.exe', ['/s', '/c', 'chcp 65001'], {
+            stdio: 'ignore',
+        });
+
+        restore();
+        expect(spawnSync).toHaveBeenNthCalledWith(3, 'cmd.exe', ['/s', '/c', 'chcp 850'], {
+            stdio: 'ignore',
+        });
+    });
+
+    it('only restores once, even if called multiple times', () => {
+        const spawnSync = vi.fn().mockReturnValue(ok('Active code page: 850.'));
+        const restore = ensureUtf8Codepage(spawnSync as unknown as SpawnSync, win32);
+
+        restore();
+        restore();
+        expect(spawnSync).toHaveBeenCalledTimes(3);
+    });
+
+    it('does nothing and never throws when reading the codepage fails', () => {
+        const spawnSync = vi.fn().mockReturnValue(failed());
+        const restore = ensureUtf8Codepage(spawnSync as unknown as SpawnSync, win32);
+
+        expect(() => restore()).not.toThrow();
+        expect(spawnSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing and never throws when spawnSync itself throws', () => {
+        const spawnSync = vi.fn().mockImplementation(() => {
+            throw new Error('boom');
+        });
+
+        expect(() => ensureUtf8Codepage(spawnSync as unknown as SpawnSync, win32)()).not.toThrow();
+    });
+
+    it('does nothing when setting the codepage fails', () => {
+        const spawnSync = vi
+            .fn()
+            .mockReturnValueOnce(ok('Active code page: 850.'))
+            .mockReturnValueOnce(failed());
+        const restore = ensureUtf8Codepage(spawnSync as unknown as SpawnSync, win32);
+
+        expect(spawnSync).toHaveBeenCalledTimes(2);
+
+        restore();
+        // No third call: setting UTF-8 failed, so there's nothing to restore.
+        expect(spawnSync).toHaveBeenCalledTimes(2);
+    });
+});

--- a/bin/console-codepage.ts
+++ b/bin/console-codepage.ts
@@ -1,0 +1,70 @@
+import { spawnSync as baseSpawnSync } from 'node:child_process';
+import nodeProcess from 'node:process';
+
+const UTF8_CODEPAGE = 65001;
+
+export type SpawnSync = typeof baseSpawnSync;
+
+/**
+ * On Windows, concurrently pipes child-process output through a freshly-allocated console whose
+ * codepage may not be UTF-8, garbling non-ASCII output from commands that rely on it (see
+ * open-cli-tools/concurrently#302). This sets the console's codepage to UTF-8 once, which spawned
+ * children then inherit, and returns a function that restores the original codepage.
+ *
+ * No-ops (and never throws) if not on Windows, if the codepage is already UTF-8, or if reading/setting
+ * it fails for any reason -- this is a best-effort convenience, never something that should block
+ * concurrently from running.
+ */
+export function ensureUtf8Codepage(
+    spawnSync: SpawnSync = baseSpawnSync,
+    process: Pick<NodeJS.Process, 'platform'> = nodeProcess,
+): () => void {
+    const noop = () => {};
+    if (process.platform !== 'win32') {
+        return noop;
+    }
+
+    try {
+        const original = readCodepage(spawnSync);
+        if (original == null || original === UTF8_CODEPAGE) {
+            return noop;
+        }
+        if (!setCodepage(spawnSync, UTF8_CODEPAGE)) {
+            return noop;
+        }
+
+        let restored = false;
+        return () => {
+            if (restored) {
+                return;
+            }
+            restored = true;
+            try {
+                setCodepage(spawnSync, original);
+            } catch {
+                // Best-effort restore; nothing more we can do.
+            }
+        };
+    } catch {
+        return noop;
+    }
+}
+
+function readCodepage(spawnSync: SpawnSync): number | null {
+    const result = spawnSync('cmd.exe', ['/s', '/c', 'chcp'], { encoding: 'utf8' });
+    if (result.error || result.status !== 0 || !result.stdout) {
+        return null;
+    }
+    // Locale-dependent text (e.g. "Active code page: 65001." or "Aktive Codepage: 65001."),
+    // so match on the number rather than the surrounding words.
+    const match = /(\d+)/.exec(result.stdout);
+    return match ? Number(match[1]) : null;
+}
+
+function setCodepage(spawnSync: SpawnSync, codepage: number): boolean {
+    // `chcp` changes the codepage of the console this process is attached to regardless of where its
+    // own stdio points, so output can be safely discarded here rather than inherited -- otherwise its
+    // confirmation text (e.g. "Active code page: 65001.") would leak into concurrently's own output.
+    const result = spawnSync('cmd.exe', ['/s', '/c', `chcp ${codepage}`], { stdio: 'ignore' });
+    return !result.error && result.status === 0;
+}

--- a/bin/index.ts
+++ b/bin/index.ts
@@ -7,6 +7,7 @@ import { hideBin } from 'yargs/helpers';
 import * as defaults from '../lib/defaults.js';
 import { concurrently } from '../lib/index.js';
 import { castArray, splitOutsideParens } from '../lib/utils.js';
+import { ensureUtf8Codepage } from './console-codepage.js';
 import { normalizeCliCommand } from './normalize-cli-command.js';
 import { readPackageJson } from './read-package-json.js';
 
@@ -229,40 +230,54 @@ if (!commands.length) {
     process.exit();
 }
 
-concurrently(
-    commands.map((command, index) => ({
-        command: normalizeCliCommand(String(command)),
-        name: names[index],
-    })),
-    {
-        handleInput: args.handleInput,
-        defaultInputTarget: args.defaultInputTarget,
-        killOthersOn: args.killOthers
-            ? ['success', 'failure']
-            : args.killOthersOnFail
-              ? ['failure']
-              : [],
-        killSignal: args.killSignal,
-        killTimeout: args.killTimeout,
-        maxProcesses: args.maxProcesses,
-        raw: args.raw,
-        hide: args.hide.split(','),
-        group: args.group,
-        prefix: args.prefix,
-        prefixColors: splitOutsideParens(args.prefixColors, ','),
-        prefixLength: args.prefixLength,
-        padPrefix: args.padPrefix,
-        restartDelay:
-            args.restartAfter === 'exponential' ? 'exponential' : Number(args.restartAfter),
-        restartTries: args.restartTries,
-        successCondition: args.success,
-        timestampFormat: args.timestampFormat,
-        timings: args.timings,
-        shell: args.shell,
-        teardown: args.teardown,
-        additionalArguments: args.passthroughArguments ? additionalArguments : undefined,
-    },
-).result.then(
-    () => process.exit(0),
-    () => process.exit(1),
-);
+// Piped output on Windows uses the console's active codepage, which may not be UTF-8 -- see
+// open-cli-tools/concurrently#302. Raw mode inherits the real console directly instead of piping
+// through concurrently, so it isn't affected and doesn't need this.
+const restoreCodepage = args.raw ? () => {} : ensureUtf8Codepage();
+const exitProcess = (code: number) => {
+    restoreCodepage();
+    process.exit(code);
+};
+
+try {
+    concurrently(
+        commands.map((command, index) => ({
+            command: normalizeCliCommand(String(command)),
+            name: names[index],
+        })),
+        {
+            handleInput: args.handleInput,
+            defaultInputTarget: args.defaultInputTarget,
+            killOthersOn: args.killOthers
+                ? ['success', 'failure']
+                : args.killOthersOnFail
+                  ? ['failure']
+                  : [],
+            killSignal: args.killSignal,
+            killTimeout: args.killTimeout,
+            maxProcesses: args.maxProcesses,
+            raw: args.raw,
+            hide: args.hide.split(','),
+            group: args.group,
+            prefix: args.prefix,
+            prefixColors: splitOutsideParens(args.prefixColors, ','),
+            prefixLength: args.prefixLength,
+            padPrefix: args.padPrefix,
+            restartDelay:
+                args.restartAfter === 'exponential' ? 'exponential' : Number(args.restartAfter),
+            restartTries: args.restartTries,
+            successCondition: args.success,
+            timestampFormat: args.timestampFormat,
+            timings: args.timings,
+            shell: args.shell,
+            teardown: args.teardown,
+            additionalArguments: args.passthroughArguments ? additionalArguments : undefined,
+        },
+    ).result.then(
+        () => exitProcess(0),
+        () => exitProcess(1),
+    );
+} catch (error) {
+    restoreCodepage();
+    throw error;
+}


### PR DESCRIPTION
Closes #302.

I looked into this and your `chcp 65001 && <command>` idea from 2023 doesn't actually work if you inline it as a single command like that — `chcp` runs and reports success, but the CJK text is already garbled by the time it prints. cmd.exe seems to convert the whole `/c` command-line argument using the codepage that was active before `chcp` gets a chance to run. Confirmed on a real Windows 11 machine with raw byte output, not just what shows in a terminal.

What does work: setting the codepage on concurrently's own process once at startup — basically what the original reporter's own `chcp 65001 && concurrently ...` workaround was doing, since the codepage is a property of the console session and a freshly-piped child inherits whatever its parent console is set to. This does that in the CLI entry point only (not the library API, so nothing changes for anyone using concurrently programmatically), restores the original codepage on exit, and is a no-op if the codepage is already UTF-8 (increasingly common with Windows Terminal etc). Cost is one `chcp` probe at startup on Windows, and nothing at all on other platforms or under `--raw`.

Also tried cmd's own `/U` flag, since it doesn't need `chcp` at all. Doesn't help though — it only affects cmd.exe's own builtins, has zero effect on output from an external process like Node, and would have actively broken the currently-correct output from Node-based commands (most real usage), since it flips the encoding to UTF-16LE.

Before:

```
> npm run test
[0] ??
```

After:

```
> npm run test
[0] 你好
```

One thing I'm not sure about: since codepage is a per-console-session property, not per-process, this could in principle race with another codepage-sensitive tool running in the same terminal at the same time. It's scoped to the CLI only, and the restore hangs off the same completion path concurrently already uses for Ctrl+C, so I think the risk is small — but happy to put it behind a flag instead if you'd rather it not be automatic. WDYT?
