### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /tests/cjs-require
@@ -16,7 +16,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /tests/cjs-import
@@ -25,7 +25,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /tests
@@ -34,7 +34,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: npm
     directory: /
@@ -43,7 +43,7 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'
 
   - package-ecosystem: github-actions
     directory: /
@@ -52,4 +52,4 @@ updates:
     groups:
       all-dependencies:
         patterns:
-          - "*"
+          - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /tests/esm
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /tests/cjs-require
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /tests/cjs-import
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /tests
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add a Dependabot configuration so GitHub can automatically open PRs when npm dependencies (in `/`, `/tests`, `/tests/esm`, `/tests/cjs-require`, `/tests/cjs-import`) or GitHub Actions pins fall behind.

**Configuration choices:**
- Weekly schedule — a good balance between staying current and minimising PR noise
- Updates grouped per ecosystem into a single PR — avoids one PR per package

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
