### PR TITLE
docs: update issue link to the transferred repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Check out documentation and other usage examples in the [`docs` directory](./doc
   - `handleInput`: when `true`, reads input from `process.stdin`.
   - `inputStream`: a [`Readable` stream](https://nodejs.org/docs/latest/api/stream.html#readable-streams)
     to read the input from. Should only be used in the rare instance you would like to stream anything other than `process.stdin`. Overrides `handleInput`.
-  - `pauseInputStreamOnFinish`: by default, pauses the input stream (`process.stdin` when `handleInput` is enabled, or `inputStream` if provided) when all of the processes have finished. If you need to read from the input stream after `concurrently` has finished, set this to `false`. ([#252](https://github.com/kimmobrunfeldt/concurrently/issues/252)).
+  - `pauseInputStreamOnFinish`: by default, pauses the input stream (`process.stdin` when `handleInput` is enabled, or `inputStream` if provided) when all of the processes have finished. If you need to read from the input stream after `concurrently` has finished, set this to `false`. ([#252](https://github.com/open-cli-tools/concurrently/issues/252)).
   - `killOthersOn`: once the first command exits with one of these statuses, kill other commands.
     Can be an array containing the strings `success` (status code zero) and/or `failure` (non-zero exit status).
   - `maxProcesses`: how many processes should run at once.


### PR DESCRIPTION
The README links to `github.com/kimmobrunfeldt/concurrently/issues/252` — the repo's pre-transfer path. GitHub's redirect for the old org's issue URLs is not working (404), while `github.com/open-cli-tools/concurrently/issues/252` serves the issue correctly (200). Updated the link.