### PR TITLE
docs: update import example for v10 named export

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Check out documentation and other usage examples in the [`docs` directory](./doc
 Example:
 
 ```js
-const concurrently = require('concurrently');
+const { concurrently } = require('concurrently');
 const { result } = concurrently(
   [
     'npm:watch-*',


### PR DESCRIPTION
Fixes #606. v10 changed the export from default to named. Updated the programmatic API example to use `const { concurrently } = require("concurrently")`.