### PR TITLE
docs: update API example to ESM

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ Check out documentation and other usage examples in the [`docs` directory](./doc
 Example:
 
 ```js
-const concurrently = require('concurrently');
+import path from 'node:path';
+import { concurrently } from 'concurrently';
+
 const { result } = concurrently(
   [
     'npm:watch-*',
@@ -148,14 +150,14 @@ const { result } = concurrently(
     {
       command: 'watch',
       name: 'watch',
-      cwd: path.resolve(__dirname, 'scripts/watchers'),
+      cwd: path.resolve(import.meta.dirname, 'scripts/watchers'),
     },
   ],
   {
     prefix: 'name',
     killOthersOn: ['failure', 'success'],
     restartTries: 3,
-    cwd: path.resolve(__dirname, 'scripts'),
+    cwd: path.resolve(import.meta.dirname, 'scripts'),
   },
 );
 result.then(success, failure);


### PR DESCRIPTION
concurrently v10 is pure ESM (type: module, and exports maps only ./dist/lib/index.js), so the README example no longer runs as written:

  const concurrently = require('concurrently');   // -> namespace object
  concurrently([...]);                            // TypeError: not a function

Verified against the published concurrently@10.0.5 on Node 22.

Switch the example to a named ESM import and replace __dirname, which does not exist in an ES module, with import.meta.dirname (Node >=20.11; package engines already require >=22).

Closes #606