### PR TITLE
fix: skip force-kill logging when no processes remain

### DIFF
--- a/lib/flow-control/kill-others.spec.ts
+++ b/lib/flow-control/kill-others.spec.ts
@@ -134,6 +134,22 @@ it('force kills misbehaving processes after a timeout', () => {
     expect(commands[2].kill).toHaveBeenCalledTimes(1);
 });
 
+it('does not report a force kill when all processes exit before the timeout', () => {
+    vi.useFakeTimers();
+
+    createWithConditions(['failure'], { timeoutMs: 500 }).handle(commands);
+    assignProcess(commands[1]);
+    commands[1].kill = vi.fn(() => unassignProcess(commands[1]));
+    commands[0].close.next(createFakeCloseEvent({ exitCode: 1 }));
+
+    vi.advanceTimersByTime(500);
+
+    expect(commands[1].kill).toHaveBeenCalledExactlyOnceWith(undefined);
+    expect(logger.logGlobalEvent).toHaveBeenCalledExactlyOnceWith(
+        'Sending SIGTERM to other processes..',
+    );
+});
+
 it('does not keep the event loop alive while waiting to force kill', () => {
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
 

--- a/lib/flow-control/kill-others.ts
+++ b/lib/flow-control/kill-others.ts
@@ -81,7 +81,7 @@ export class KillOthers implements FlowController {
 
         setTimeout(() => {
             const killableCommands = commands.filter((command) => Command.canKill(command));
-            if (killableCommands) {
+            if (killableCommands.length) {
                 this.logger.logGlobalEvent(
                     `Sending SIGKILL to ${killableCommands.length} processes..`,
                 );


### PR DESCRIPTION
## Summary

- avoid logging a force-kill event when no processes remain killable
- cover processes that exit after the initial termination signal

## Problem

When `killTimeout` is enabled, a process may exit normally after receiving the initial termination signal. The timeout callback currently treats the resulting empty command array as truthy and logs `Sending SIGKILL to 0 processes..`, even though no force kill occurs.

## Fix

Only log and send `SIGKILL` when the timeout callback finds at least one process that is still killable.

## Testing

- `pnpm vitest run --project unit lib/flow-control/kill-others.spec.ts`
- `CI=1 pnpm test`
- `pnpm exec vitest --coverage`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format`
- `pnpm build`
- `pnpm test:smoke`
